### PR TITLE
feat: add startswith filter to py wrapper filters

### DIFF
--- a/nornflow/builtins/jinja2_filters/py_wrapper_filters.py
+++ b/nornflow/builtins/jinja2_filters/py_wrapper_filters.py
@@ -69,6 +69,11 @@ def filter_join(sep: str, iterable: Iterable[Any]) -> str:
     return sep.join(str(item) for item in iterable)
 
 
+def filter_startswith(string: str, prefix: str, start: int = 0, end: int | None = None) -> bool:
+    """Check if string starts with prefix, optionally within start and end indices."""
+    return string.startswith(prefix, start, end)
+
+
 # Registry of builtin filters
 PY_WRAPPER_FILTERS = {
     "enumerate": filter_enumerate,
@@ -84,4 +89,5 @@ PY_WRAPPER_FILTERS = {
     "reversed": filter_reversed,
     "strip": filter_strip,
     "joinx": filter_join,
+    "startswith": filter_startswith,
 }


### PR DESCRIPTION
## PR Description: Add startswith filter to py wrapper filters

### Summary
This PR adds a new `filter_startswith` function to py_wrapper_filters.py, wrapping Python's `str.startswith()` method as a Jinja2 filter. It allows templates to check if a string starts with a specified prefix, with optional start and end indices for substring checks. The filter is registered in the `PY_WRAPPER_FILTERS` dictionary under the key "startswith".

### Changes
- Added the `filter_startswith` function with type hints and a Google-style docstring.
- Updated the `PY_WRAPPER_FILTERS` registry to include the new filter.

### Motivation
The startswith filter enhances the available Jinja2 filters by providing a direct wrapper for a common Python string method, enabling more flexible template logic without custom implementations. This aligns with the project's goal of exposing Python builtins as filters.