### PR TITLE
fix(hooks)!: store_as hook with failure-path storage and hard-fail extraction (#87)

### DIFF
--- a/docs/api_reference.md
+++ b/docs/api_reference.md
@@ -395,14 +395,14 @@ from nornflow.models import TaskModel
 task = TaskModel(
     name="netmiko_send_command",
     args={"command_string": "show version"},
-    set_to="version_output"
+    store_as="version_output"
 )
 ```
 
 **Key Fields:**
 - `name`: Task name from catalog (required)
 - `args`: Task arguments (optional)
-- `set_to`: Variable storage configuration (optional hook)
+- `store_as`: Variable storage configuration (optional hook)
 - `if`: Conditional execution hook (optional hook)
 - `shush`: Output suppression hook (optional hook)
 - `single`: Single-host execution hook (optional hook)
@@ -450,7 +450,7 @@ class MyCustomHook(Hook):
 
 | Attribute | Type | Required | Description |
 |-----------|------|----------|-------------|
-| `hook_name` | `str` | **Yes** | The YAML key that activates this hook (e.g., `"if"`, `"set_to"`). Without this, the class is never registered. |
+| `hook_name` | `str` | **Yes** | The YAML key that activates this hook (e.g., `"if"`, `"store_as"`). Without this, the class is never registered. |
 | `run_once_per_task` | `bool` | No (default `False`) | If `True`, hook logic runs only for the first host per task; subsequent hosts skip execution. Use for task-wide concerns (e.g., suppressing output, logging). If `False`, runs independently per host. |
 | `requires_deferred_templates` | `bool` | No (default `False`) | If `True`, signals `NornFlowVariableProcessor` to defer resolution of task argument templates until after the hook's pre-execution logic completes. See [Hook-Driven Template Resolution](./hooks_guide.md#hook-driven-template-resolution). |
 
@@ -541,6 +541,17 @@ NornFlow recursively scans all configured directories for `.py` files and import
 
 **Hook-specific registration constraint:**
 - Hook subclasses that do not define `hook_name` as a non-empty string raise `HookRegistrationError` at class definition time
+
+**Built-in hook catalog (YAML key → class):**
+
+| YAML key | Class | Summary |
+|----------|-------|---------|
+| `if` | `IfHook` | Conditional task execution per host |
+| `store_as` | `StoreAsHook` | Store task return value or extracted fields as runtime variables |
+| `shush` | `ShushHook` | Suppress task output display |
+| `single` | `SingleHook` | Run task on one host only |
+
+See the [Hooks Guide](./hooks_guide.md#nornflows-built-in-hooks) for configuration examples.
 
 Built-in protection and non-builtin override behavior follow the [universal registration rules](#universal-registration-rules) that apply to all asset types.
 

--- a/docs/blueprints_guide.md
+++ b/docs/blueprints_guide.md
@@ -109,12 +109,12 @@ tasks:
   - name: netmiko_send_command
     args:
       command_string: "show ip interface brief"
-    set_to: interfaces
+    store_as: interfaces
   
   - name: netmiko_send_command
     args:
       command_string: "show ip route summary"
-    set_to: routes
+    store_as: routes
   
   - name: echo
     args:
@@ -135,7 +135,7 @@ tasks:
   - name: netmiko_send_command
     args:
       command_string: "show ip interface brief"
-    set_to: interfaces
+    store_as: interfaces
 ```
 
 **Example output from `nornflow show -b` *(see 'Description' column)* :** 
@@ -402,7 +402,7 @@ During assembly-time, blueprints have access to these variable sources (highest 
 5. **Environment Variables** (`NORNFLOW_VAR_*`)
 
 **NOT available at assembly-time:**
-- Runtime variables (set by `set` task or `set_to` hook)
+- Runtime variables (set by `set` task or `store_as` hook)
 - Host inventory data (`host.*` namespace)
 
 **Example:**

--- a/docs/core_concepts.md
+++ b/docs/core_concepts.md
@@ -470,7 +470,7 @@ Built-ins register first and **claim bare names unconditionally**. A local or pa
 |---|---|---|
 | Tasks | `echo`, `set`, `write_file`, `pause` | Bare resolves to `nornflow.*` when present |
 | Filters | `hosts`, `groups` | Bare resolves to `nornflow.*` when present |
-| Hooks | `if`, `set_to`, `shush`, `single` | Bare resolves to `nornflow.*` when present |
+| Hooks | `if`, `store_as`, `shush`, `single` | Bare resolves to `nornflow.*` when present |
 | Jinja2 Filters | NornFlow's built-in j2 filters | Bare resolves to `nornflow.*` when present |
 | Workflows | — no builtins — | n/a |
 | Blueprints | — no builtins — | n/a |
@@ -593,9 +593,9 @@ tasks:
       interface: "GigabitEthernet0/1"
       description: "Uplink to {{ host.data.upstream_device }}"
       
-  # Task with result capture
+  # Task with result storage (simple mode — stores Result.result)
   - name: show_version
-    set_to: version_info  # Stores result in 'version_info' variable
+    store_as: version_info
 ```
 
 ### Task Arguments & Results
@@ -605,16 +605,17 @@ tasks:
 - Supports Jinja2 templating for dynamic values
 - Can reference variables and host data
 
-**Capturing Results:**
-- Use `set_to` to store task results in variables
-- Results are available to subsequent tasks
+**Storing results:**
+- Use `store_as` to store the task return value (`Result.result`) or extracted fields in runtime variables
+- Values are available to subsequent tasks on the same host
 - Stored per-device in isolated contexts
+- `store_as` runs on both successful and failed tasks (unless the host was skipped)
 
 **Example:**
 ```yaml
 tasks:
   - name: show_version
-    set_to: version_info  # Stores the result in the variable 'version_info'. The var will be either created or updated on a per-device context basis.
+    store_as: version_info
 
   - name: echo
     args:
@@ -769,21 +770,22 @@ tasks:
     if: "{{ host.data.backup_enabled and environment == 'prod' }}"
 ```
 
-**`set_to` Hook - Result Storage**
+**`store_as` Hook - Result Storage**
 
-Captures task execution results and stores them as runtime variables for use in subsequent tasks.
+Stores the task return value or extracted fields as runtime variables for use in later tasks. Simple mode (`store_as: var_name`) stores `Result.result` — not the full Nornir `Result` object. See the [Hooks Guide](./hooks_guide.md#the-store_as-hook) for path syntax and failure-path examples.
 
 ```yaml
 tasks:
-  # Store complete result
+  # Simple mode — same as store_as: { device_facts: result }
   - name: get_facts
-    set_to: device_facts
+    store_as: device_facts
   
-  # Extract specific data from result
+  # Extraction mode
   - name: get_environment
-    set_to:
+    store_as:
       cpu_usage: "environment.cpu.0.%usage"
       serial: "serial_number"
+      step_failed: failed
   
   # Use stored data in later tasks
   - name: echo
@@ -800,7 +802,7 @@ tasks:
   # Static suppression
   - name: noisy_task
     shush: true
-    set_to: task_result  # Result still available
+    store_as: task_result  # Return value still available to later tasks
   
   # Dynamic suppression based on variables
   - name: conditional_quiet

--- a/docs/failure_strategies.md
+++ b/docs/failure_strategies.md
@@ -11,6 +11,7 @@ NornFlow provides flexible failure handling strategies that control how the work
 - [Behavior Examples](#behavior-examples)
 - [Failure Summary](#failure-summary)
 - [Understanding Threading Behavior](#understanding-threading-behavior)
+- [What Failure Strategies Do Not Cover](#what-failure-strategies-do-not-cover)
 - [Best Practices](#best-practices)
 
 ## Available Strategies
@@ -192,6 +193,26 @@ When working with failure strategies, it's important to understand NornFlow's th
 - The `skip-failed` strategy lets Nornir's default behavior handle removing failed hosts from subsequent tasks
 
 This threading model explains why, even with `fail-fast`, some tasks might complete after a failure is detected. Only new tasks are prevented from starting.
+
+## What Failure Strategies Do Not Cover
+
+Failure strategies control whether NornFlow **continues running tasks and hosts** after a task reports `failed=True`. They do **not** change how hooks validate their own configuration or extracted data.
+
+### `store_as` extraction errors (hard-fail)
+
+When a task uses `store_as` in **extraction mode** and a path cannot be resolved, NornFlow raises an Exception and the workflow **stops**. No failure strategy (`skip-failed`, `fail-fast`, or `run-all`) overrides this.
+
+Common cases:
+
+- A path references a key that does not exist in the task return value
+- A shorthand path needs `Result.result`, but the task returned `None`
+- The path syntax is invalid
+
+**Practical guidance:** on tasks that may fail, use `store_as: { step_failed: failed }` when you only need the failure flag for branching. Do not add optional payload paths on the same task unless those keys are guaranteed to exist even on failure.
+
+For path rules, simple-mode equivalence, and a failure-path workflow example, see the [`store_as` hook documentation](./hooks_guide.md#the-store_as-hook).
+
+Note: **`store_as` still runs on failed tasks** when paths are valid — for example `failed: true` is stored after a task failure. Failure strategy and `store_as` address different concerns: the former controls *what runs next*; the latter controls *what gets stored* and *whether bad paths abort the run*.
 
 ## Best Practices
 

--- a/docs/hooks_guide.md
+++ b/docs/hooks_guide.md
@@ -282,7 +282,7 @@ tasks:
     store_as: running_config  
 ```
 
-**What gets stored:** the data the task returned (string, dict, list, or `None`). This is **not** the full Nornir `Result` object (`failed`, `changed`, and similar fields stay on `Result`, not in your variable). For the specific example above, `store_as` would take the `Result.result` returned by the `netmiko_send_command(command_string='show running-config')` and save it into a var named 'running_config' for each host where it ran successfully.
+**What gets stored:** the data the task returned (string, dict, list, or `None`). This is **not** the full Nornir `Result` object (`failed`, `changed`, and similar fields stay on `Result`, not in your variable). For the specific example above, `store_as` would take the `Result.result` returned by the `netmiko_send_command(command_string='show running-config')` and save it into a var named `running_config` for each host where the task ran (success or failure).
 
 **Same thing, extraction syntax:**
 It's also important to understand that:
@@ -314,7 +314,7 @@ tasks:
       task_failed: failed
 ```
 
-Each path is resolved per host; each value is stored under the name you choose as each of the nested keys under `sotre_as`.
+Each path is resolved per host; each top-level key under `store_as` is the runtime variable name, and its value is the extraction path.
 
 #### How paths pick a starting point
 

--- a/docs/hooks_guide.md
+++ b/docs/hooks_guide.md
@@ -9,7 +9,7 @@
 - [Hook-Driven Template Resolution](#hook-driven-template-resolution)
 - [Built-in Hooks](#nornflows-built-in-hooks)
   - [The `if` Hook](#the-if-hook)
-  - [The `set_to` Hook](#the-set_to-hook)
+  - [The `store_as` Hook](#the-store_as-hook)
   - [The `shush` Hook](#the-shush-hook)
   - [The `single` Hook](#the-single-hook)
 - [Hook Configuration](#hook-configuration)
@@ -258,70 +258,153 @@ tasks:
 
 Without deferred processing, this would fail on hosts missing `feature_template`. With deferred processing, only hosts that pass the `if` condition have their templates resolved.
 
-### The `set_to` Hook
+### The `store_as` Hook
 
-You are encouraged to refer to the source code for the `set_to` Hook [here](../nornflow/builtins/hooks/set_to.py), but here is a summary of how it works:
+See the implementation in [`store_as.py`](../nornflow/builtins/hooks/store_as.py).
 
-1. **Validation**: Checks configuration format during task preparation
-2. **task_instance_completed**: Runs after task completes on each host
-3. **Storage**: Stores extracted value as runtime variable for the host
+The `store_as` hook saves task output into **runtime variables** so later tasks can use it in Jinja templates. It runs after each host finishes a task (unless that host was skipped by the `if` or `single` hook).
 
-The actual data captured depends on the configuration format used for the `set_to` hook:  
-   - In *simple mode*, the entire Nornir's `Result` object returned by a task execution is captured and assigned
-   - In *extraction mode*, you specify exactly what nested data out of the `Result` object you want to capture and assign to your variable.
+**Behavior you should know:**
 
-#### Configuration Formats
+- **`store_as` runs when a task succeeds or fails** — a failed task can still populate variables.
+- **Skipped hosts store nothing** — if the task did not run for a host, no variable is written for that host.
+- **Bad extraction paths stop the workflow** — invalid paths raise `HookValidationError`. This is **not** controlled by [failure strategy](./failure_strategies.md#what-failure-strategies-do-not-cover).
 
-**Simple Mode (stores the complete Nornir's `Result` object)**
+#### Simple mode
+
+Store the task's return value (i.e. Nornir's `Result.result` field) in one variable:
+
 ```yaml
 tasks:
   - name: netmiko_send_command
     args:
-      command_string: "show version"
-    set_to: device_facts # stores the entire Result object returned by `netmiko_send_command` to a 'device_facts' var
+      command_string: "show running-config"
+    store_as: running_config  
 ```
 
-**Extraction Mode (extracts specific data from the Nornir's `Result.result` object)**
+**What gets stored:** the data the task returned (string, dict, list, or `None`). This is **not** the full Nornir `Result` object (`failed`, `changed`, and similar fields stay on `Result`, not in your variable). For the specific example above, `store_as` would take the `Result.result` returned by the `netmiko_send_command(command_string='show running-config')` and save it into a var named 'running_config' for each host where it ran successfully.
+
+**Same thing, extraction syntax:**
+It's also important to understand that:
+```yaml
+store_as: running_config  
+```
+
+Is just a shorthand for:
+
+```yaml
+store_as:
+  running_config: result
+```
+
+We call the first form 'simple mode' and the latter 'extraction mode'. Both forms store the identical value for the same task output. Use whichever reads clearer in your workflow.
+
+#### Extraction mode
+
+Map variable names to paths that pick nested data from the task outcome:
+
 ```yaml
 tasks:
   - name: napalm_get
     args:
       getters: ["facts", "interfaces"]
-    set_to:
-      mgmt_ip: "interfaces.Management1.ipv4.address" # stores the IPv4 Address deeply nested in the Result object returned by the `napalm_get` task to a var named 'mgmt_ip'
+    store_as:
+      device_vendor: vendor
+      mgmt_ip: "interfaces.Management1.ipv4.address"
+      task_failed: failed
 ```
 
-#### Extraction Path Syntax
+Each path is resolved per host; each value is stored under the name you choose as each of the nested keys under `sotre_as`.
 
-Access data from `Result.result` dictionary using:
+#### How paths pick a starting point
 
-**Dot notation for nested dicts:**
+The **first segment** of a path (the part before the first `.`) decides where lookup begins:
 
-The below would update/create two NornFlow vars named "**vendor**" (with the value extracted from `Result.result['vendor']`) and "**cpu**" (with the value extracted from `Result.result['environment']['cup']['usage']`)
+| First segment | Meaning | Examples |
+|---------------|---------|----------|
+| A **top-level `Result` attribute** | Start on the Nornir `Result` object | `failed`, `changed`, `result`, `name` |
+| **Anything else** | **Shorthand** — start inside the task return value (`Result.result`) | `vendor`, `hostname`, `environment.cpu.usage` |
+
+**Typical case:** you want a field from what the task returned -> use shorthand (`vendor`, `hostname`, …).
+
+**Use a `Result` attribute** when you need task metadata:
+
+- `failed` — whether this task failed on this host
+- `changed` — whether the task reported a change
+- `result` — the full task return value (same as simple mode)
+
+**Use `result.<key>`** when the bare name could mean both a `Result` attribute and a key inside the return value (see collisions below).
+
+#### Shorthand vs explicit `result.*`
+
+When the first segment is **not** a `Result` attribute, these store the same value:
 
 ```yaml
-set_to:
+store_as:
+  from_shorthand: vendor
+  from_explicit: result.vendor
+```
+
+Both read the `vendor` field from the task's returned `Result.result` dict.
+
+#### Name collisions
+
+If the same name exists on **both** the Nornir `Result` object **and** inside `Result.result`, the **bare path uses the `Result` attribute**:
+
+```yaml
+# If Result.vendor exists AND the return dict has key "vendor":
+store_as:
+  from_wrapper: vendor           # → Result.vendor
+  from_return_value: result.vendor  # → return Result.result["vendor"]
+```
+
+When in doubt, use the extraction mode with the fully qualified name, starting explicitly from the `Result` attribute you want the lookup to begin with.
+
+#### Path syntax
+
+Combine dot notation and bracket indexes:
+
+```yaml
+store_as:
   vendor: "vendor"
   cpu: "environment.cpu.usage"
-```
-
-**Bracket notation for lists:**
-
-The below would update/create two NornFlow vars named "**first_cpu**" (with the value extracted from `Result.ressult['environment']['cpu'][0]['usage']`) and "**interface_ip**" (with the value extracted from `Result.result['interfaces']['eth0']['ipv4'][0]['address']`). 
-
-```yaml
-set_to:
   first_cpu: "environment.cpu[0].usage"
   interface_ip: "interfaces.eth0.ipv4[0].address"
+  task_failed: "failed"
+  full_return: "result"
 ```
 
-**Special prefixes for Result attributes:**
+If a segment is missing, or shorthand needs `Result.result` but it is `None`, the hook raises `HookValidationError` and the workflow stops.
+
+#### Failure-path example
+
+Store failure state, then branch with `if`:
+
 ```yaml
-set_to:
-  task_failed: "_failed" # the `Result.failed` object
-  task_changed: "_changed" # the `Result.changed` object
-  complete_result: "_result" # the `Result.result` object
+workflow:
+  name: Conditional rollback
+  failure_strategy: run-all
+  tasks:
+    - name: nornflow.write_file
+      args:
+        filename: ""
+        content: "x"
+      store_as:
+        step_failed: failed # Nornir's Result object includes a bool attr named 'failed'
+
+    - name: nornflow.echo
+      if: "{{ step_failed }}"
+      args:
+        msg: "Running rollback because the previous step failed"
 ```
+
+On a failed host, `step_failed` is `true` and the echo runs. On a successful host, `step_failed` is `false` and the echo is skipped.
+
+#### Lifecycle summary
+
+1. **Validation** — configuration format is checked during workflow preparation.
+2. **task_instance_completed** — runs after the task finishes on each host (unless skipped).
+3. **Storage** — extracted values are written to the runtime variable manager for that host.
 
 ### The `shush` Hook
 
@@ -356,11 +439,11 @@ vars:
 tasks:
   - name: backup_config
     shush: "{{ not debug_mode }}"  # Suppress unless debugging
-    set_to: config_backup
+    store_as: config_backup
     
   - name: get_facts
     shush: "{{ quiet_mode }}"  # Suppress based on variable
-    set_to: device_facts
+    store_as: device_facts
     
   - name: show_interfaces
     shush: "{{ host.platform == 'ios'}}"  # dynamic condition
@@ -520,7 +603,7 @@ tasks:
     args:                  # Task arguments
       arg1: true
       arg2: "device"
-    set_to: result_var     # Hook configuration
+    store_as: result_var     # Hook configuration
 
 # ❌ Incorrect - hooks inside args block
 tasks:
@@ -528,7 +611,7 @@ tasks:
     args:
       arg1: true
       arg2: "device"
-      set_to: result_var       # Wrong! This is passed to task function
+      store_as: result_var       # Wrong! This is passed to task function
 ```
 
 ### Multiple Hooks per Task
@@ -539,14 +622,14 @@ Tasks can use multiple hooks simultaneously:
 tasks:
   - name: get_data
     if: "{{ should_run }}"
-    set_to: captured_data
+    store_as: captured_data
     shush: true
 ```
 
 **Execution order:**
 1. `if` hook evaluates condition (task_instance_started)
 2. If condition passes, task executes
-3. `set_to` hook captures results (task_instance_completed)
+3. `store_as` hook captures results (task_instance_completed)
 4. `shush` hook affects output display
 
 ## Creating Your Custom Hooks
@@ -764,7 +847,7 @@ class MyHook(Hook):
 
 ```
 
-Use this when your hook needs to evaluate conditions or perform actions specific to each individual host. Examples: conditional execution based on host attributes (`if`), storing per-host results (`set_to`), or per-host validation.
+Use this when your hook needs to evaluate conditions or perform actions specific to each individual host. Examples: conditional execution based on host attributes (`if`), storing per-host results (`store_as`), or per-host validation.
 
 
 ### Context Access

--- a/docs/packages_guide.md
+++ b/docs/packages_guide.md
@@ -19,6 +19,8 @@
 
 ## Overview
 
+> **Reference package:** [nornflow-arista](https://github.com/NornFlow/nornflow_arista) is the first NornFlow-compatible companion package. Use it as a practical example when learning the feature or authoring your own package — it demonstrates the directory layout, eAPI connection wiring, and how tasks, workflows, blueprints, filters, hooks, Jinja2 filters, and processors plug into NornFlow.
+
 The `packages` setting lets you pull NornFlow resources — tasks, workflows, blueprints, filters, hooks, Jinja2 filters, and processors — from external Python packages installed in your environment.
 
 The workflow is simple: install a NornFlow-compatible package, declare it in `nornflow.yaml`, and NornFlow discovers and catalogs its resources using the exact same mechanisms it uses for your local directories.

--- a/docs/packages_guide.md
+++ b/docs/packages_guide.md
@@ -239,7 +239,7 @@ Hooks follow the same namespace model as all other asset types. Built-in hooks l
 
 The only hook-specific behavior is in `Hook.__init_subclass__`: any `Hook` subclass that does not define `hook_name` as a non-empty string raises `HookRegistrationError` at class definition time.
 
-Bare `set_to` resolves to the built-in hook. A package hook named `set_to` is reachable as `my_pkg.set_to`. Reusing a built-in hook name in a package no longer halts initialization.
+Bare `store_as` resolves to the built-in hook. A package hook named `store_as` is reachable as `my_pkg.store_as`. Reusing a built-in hook name in a package no longer halts initialization.
 
 ## Error Reference
 

--- a/docs/quick_start.md
+++ b/docs/quick_start.md
@@ -190,7 +190,7 @@ workflow:
     - name: netmiko_send_command
       args:
         command_string: "show running-config"
-      set_to: "running_config"
+      store_as: running_config
     
     - name: write_file
       args:
@@ -260,12 +260,12 @@ tasks:
   - name: netmiko_send_command
     args:
       command_string: "show version"
-    set_to: version_output
+    store_as: version_output
   
   - name: netmiko_send_command
     args:
       command_string: "show interfaces status"
-    set_to: interfaces_output
+    store_as: interfaces_output
 ```
 
 ### Use in Workflow

--- a/docs/variables_basics.md
+++ b/docs/variables_basics.md
@@ -223,7 +223,7 @@ tasks:
 
 **Path shorthand:** if the first segment is **not** a top-level `Result` attribute, lookup starts inside the `Result.result` value. For example, `uptime_seconds: "environment.uptime"` reads `Result.result["environment"]["uptime"]` from the task return value.
 
-**`Result` attributes:** use paths like `failed`, `changed`, `result` (or any other customer attr name) when you need to be specific about where the lookup should start in the Nornir `Result` object.
+**`Result` attributes:** use paths like `failed`, `changed`, `result` (or any other custom attribute name on the Nornir `Result` object) when you need to be specific about where the lookup should start.
 
 **Explicit return-value access:** prefix a path with `result.` when the first segment could match both a `Result` attribute and a key in the return value. For `uptime_seconds` in the example above:
 

--- a/docs/variables_basics.md
+++ b/docs/variables_basics.md
@@ -164,7 +164,7 @@ CLI variables override `workflow`, `domain`, `global`, and `environment` variabl
 Runtime variables are the highest priority variables in NornFlow's variable system. They can be created or updated in two ways:
 
 1. **Using NornFlow's built-in `set` task**
-2. **Using NornFlow's built-in `set_to` hook to capture task results**
+2. **Using NornFlow's built-in `store_as` hook to store task results**
 
 #### Using the `set` Task
 
@@ -187,117 +187,93 @@ When this task runs:
 - If variables with these names already exist, they are updated with the new values
 - Variables are isolated per device - each host has its own `timestamp`, `device_type`, etc.
 
-#### Using the `set_to` Hook
+#### Using the `store_as` Hook
 
-The `set_to` hook captures task execution results and stores them as runtime variables. It supports two modes:
+The `store_as` hook stores task execution results as runtime variables. See the [Hooks Guide](./hooks_guide.md#the-store_as-hook) for full path syntax, collision rules, and failure-path examples.
 
-##### Simple Storage Mode
+##### Simple mode
 
-Store the complete Nornir `Result` object from a task:
+Store the task's return value (`Result.result`) in one variable:
 
 ```yaml
 tasks:
   - name: get_version
-    set_to: version_output
+    store_as: version_output
 
   - name: echo
     args:
-      msg: "Version: {{ version_output.result }}"
+      msg: "Version: {{ version_output }}"
 ```
 
-In simple mode, `set_to: "variable_name"` stores the entire Nornir `Result` object, which includes:
-- `result`: The actual data returned by the task
-- `failed`: Boolean indicating if the task failed
-- `changed`: Boolean indicating if the task made changes
-- Other Result object attributes
+In simple mode, `store_as: version_output` stores **only** the task's `Result.result` value. It does **not** store the full Nornir `Result` object.
 
-##### Extraction Mode
+##### Extraction mode
 
-Extract specific data from the result and store it in named variables:
+Extract specific fields into named variables:
 
 ```yaml
 tasks:
   - name: get_environment
-    set_to:
+    store_as:
       cpu_usage: "environment.cpu.0.%usage"
       device_serial: "serial_number"
       uptime_seconds: "environment.uptime"
+      task_failed: failed
 ```
 
-**Extraction Path Syntax:**
+**Path shorthand:** if the first segment is **not** a top-level `Result` attribute, lookup starts inside the `Result.result` value. For example, `uptime_seconds: "environment.uptime"` reads `Result.result["environment"]["uptime"]` from the task return value.
 
-The extraction paths directly reference keys in the result data. **No `result.` prefix is needed** - NornFlow automatically looks in the result data:
+**`Result` attributes:** use paths like `failed`, `changed`, `result` (or any other customer attr name) when you need to be specific about where the lookup should start in the Nornir `Result` object.
+
+**Explicit return-value access:** prefix a path with `result.` when the first segment could match both a `Result` attribute and a key in the return value. For `uptime_seconds` in the example above:
 
 ```yaml
-# Direct key access
-set_to:
-  vendor: "vendor"              # Gets Result.result["vendor"] and sets it to a 'vendor' var
-  hostname: "hostname"          # Gets Result.result["hostname"] and sets it to a 'hostname' var
-
-# Nested dictionary access (dot notation)
-set_to:
-  cpu: "environment.cpu.usage"  # Gets Result.result["environment"]["cpu"]["usage"] and sets it to a 'cpu' var
-  
-# List indexing (bracket notation)
-set_to:
-  first_cpu: "environment.cpu[0].usage"    # Gets Result.result["environment"]["cpu"][0]["usage"] and sets it to a 'first_cpu' var  
-# Complex nested structures
-set_to:
-  value: "dict.nested_list[1].another_dict.list[10]"  # Any combination of nested access
+tasks:
+  - name: get_environment
+    store_as:
+      uptime_seconds: "result.environment.uptime"
 ```
 
-**Special Extraction Prefixes:**
+Both forms store the same value when `Result` has no `environment` attribute. If it does, `"environment.uptime"` resolves against `Result.environment`, not `Result.result` dict.
 
-Three special prefixes extract metadata from the `Result` object itself:
-
-```yaml
-set_to:
-  task_failed: "_failed"        # Gets result.failed (boolean)
-  task_changed: "_changed"      # Gets result.changed (boolean)
-  complete_data: "_result"      # Gets the entire result.result dictionary
-```
-
-**Real-World Example:**
+##### Real-world example
 
 ```yaml
 workflow:
   name: "Device Information Collection"
   tasks:
-    # Collect facts and extract specific data
     - name: napalm_get
       args:
         getters: ["facts", "environment", "interfaces"]
-      set_to:
+      store_as:
         device_model: "facts.model"
         device_serial: "facts.serial_number"
         device_vendor: "facts.vendor"
         cpu_usage: "environment.cpu.0.%usage"
         memory_used: "environment.memory.used_ram"
-        interface_count: "interfaces"  # Will store the entire interfaces dict
-        task_succeeded: "_failed"  # Store if collection failed
-    
-    # Use extracted data in subsequent tasks
+        interface_count: "interfaces"
+        step_failed: failed
+
     - name: set
       args:
         backup_filename: "{{ device_vendor }}_{{ device_model }}_{{ device_serial }}.cfg"
         high_cpu_alert: "{{ cpu_usage | int > 80 }}"
-    
-    # Conditional action based on extracted data
+
     - name: send_alert
       if: "{{ high_cpu_alert }}"
       args:
         message: "High CPU usage detected: {{ cpu_usage }}%"
 ```
 
-#### Key Differences Between `set` Task and `set_to` Hook
+#### Key Differences Between `set` Task and `store_as` Hook
 
-| Aspect | `set` Task | `set_to` Hook |
-|--------|------------|---------------|
-| **Purpose** | Create/update variables with specified values | Create/update variables with task execution results |
-| **What's stored** | Values you explicitly provide in `args` | Task's `Result` object or extracted data |
-| **When to use** | Setting calculated/templated values | Capturing output from tasks |
-| **Data format** | Any data type (strings, numbers, lists, dicts) | `Result` object or extracted values |
-| **Typical use** | Setting timestamps, counters, filenames | Storing device facts, command output, API responses |
+| Aspect | `set` Task | `store_as` Hook |
+|--------|------------|-----------------|
+| **Purpose** | Create/update variables with specified values | Create/update variables from task execution results |
+| **What's stored** | Values you explicitly provide in `args` | Task return value (`Result.result`) or extracted slices |
+| **When to use** | Setting calculated/templated values | Storing command output, device facts, failure flags |
+| **Data format** | Any data type (strings, numbers, lists, dicts) | Return value or extracted fields (strings, numbers, dicts, …) |
+| **Typical use** | Setting timestamps, counters, filenames | Storing device facts, command output, `failed` for branching |
 
 #### Variable Creation and Updates
 
@@ -322,11 +298,11 @@ tasks:
   
   # Capture task result
   - name: get_version
-    set_to: version_data  # Creates 'version_data' variable
+    store_as: version_data  # Creates 'version_data' variable
   
   # Update with new data
   - name: get_config
-    set_to: version_data  # Updates 'version_data' with new result
+    store_as: version_data  # Updates 'version_data' with new return value
 ```
 
 Runtime variables override `CLI`, `workflow`, `domain`, `global`, and `environment` variables with the same name.
@@ -455,7 +431,7 @@ For information on Hook-Driven Template Resolution, which allows deferring varia
 4. **Group related variables**: Use domain variables for domain-specific settings
 5. **Document variables**: Add comments in your variable files (`<vars_dir>/defaults.yaml` and `<vars_dir>/<domain>/default.yaml`)
 6. **Avoid name conflicts**: Don't start variable names with *`host`* to avoid confusion with the `host.` namespace
-7. **Use `set_to` extraction for cleaner code**: Extract only the data you need upfront instead of storing complete results
+7. **Use `store_as` extraction for cleaner templates**: Extract only the fields you need instead of storing large return values and drilling in later
 8. **Leverage Jinja2 filters**: Use filters to transform data, especially when working with complex structures
 
 ## Quick Reference
@@ -468,8 +444,8 @@ For information on Hook-Driven Template Resolution, which allows deferring varia
 | Workflow           | In workflow YAML                | `vars: {vlan: 100}`            | `{{ vlan }}`                 |
 | CLI                | Command line                    | `--vars "x=1"`                 | `{{ x }}`                    |
 | Runtime            | Set with `set` task             | `status: "done"`               | `{{ status }}`               |
-|                    | Set with `set_to` (simple)      | `set_to: version_output`       | `{{ version_output.result }}`|
-|                    | Set with `set_to` (extraction)  | `set_to: {vendor: "vendor"}`   | `{{ vendor }}`               |
+|                    | Set with `store_as` (simple)      | `store_as: version_output`       | `{{ version_output }}`         |
+|                    | Set with `store_as` (extraction)  | `store_as: {vendor: "custom_field.vendor"}`   | `{{ vendor }}`                 |
 | Host data          | Nornir Inventory                | `data: {site_code: NYC01}`     | `{{ host.data.site_code }}`  |
 
 **Checking Variable Existence:**
@@ -478,7 +454,7 @@ For information on Hook-Driven Template Resolution, which allows deferring varia
 |--------------------|---------------------------------|--------------------------------|
 | Default namespace  | `{{ 'var_name' \| is_set }}`    | `true` if variable exists      |
 | Host namespace     | `{{ 'host.var_name' \| is_set }}`| `true` if host attribute exists|
-| Host data          | `{{ 'host.data.key' \| is_set }}`| `true` if host data key exists |
+| Host data          | `{{ 'host.data.some_key' \| is_set }}`| `true` if host data 'some_key' exists |
 
 **Variable Context Availability:**
 

--- a/nornflow/builtins/__init__.py
+++ b/nornflow/builtins/__init__.py
@@ -5,7 +5,7 @@ This package contains the default filters and processors included with NornFlow.
 """
 
 from nornflow.builtins.filters import groups, hosts
-from nornflow.builtins.hooks import IfHook, SetToHook, ShushHook, SingleHook
+from nornflow.builtins.hooks import IfHook, ShushHook, SingleHook, StoreAsHook
 from nornflow.builtins.processors import DefaultNornFlowProcessor
 
-__all__ = ["DefaultNornFlowProcessor", "IfHook", "SetToHook", "ShushHook", "SingleHook", "groups", "hosts"]
+__all__ = ["DefaultNornFlowProcessor", "IfHook", "ShushHook", "SingleHook", "StoreAsHook", "groups", "hosts"]

--- a/nornflow/builtins/hooks/__init__.py
+++ b/nornflow/builtins/hooks/__init__.py
@@ -1,11 +1,11 @@
 from .if_hook import IfHook
-from .set_to import SetToHook
 from .shush import ShushHook
 from .single import SingleHook
+from .store_as import StoreAsHook
 
 __all__ = [
     "IfHook",
-    "SetToHook",
     "ShushHook",
     "SingleHook",
+    "StoreAsHook",
 ]

--- a/nornflow/builtins/hooks/store_as.py
+++ b/nornflow/builtins/hooks/store_as.py
@@ -13,7 +13,7 @@ if TYPE_CHECKING:
     from nornflow.models import TaskModel
 
 
-class SetToHook(Hook):
+class StoreAsHook(Hook):
     """
     Store task execution results as runtime variables with optional data extraction.
 
@@ -21,8 +21,8 @@ class SetToHook(Hook):
     Supports both simple variable storage and selective data extraction from results.
 
     Usage modes:
-    1. Simple: set_to: "var_name" - stores complete result object
-    2. Extraction: set_to: {var_name: "extraction_path"} - extracts specific data
+    1. Simple: store_as: "var_name" - stores complete result object
+    2. Extraction: store_as: {var_name: "extraction_path"} - extracts specific data
 
     For extraction paths, directly reference the keys in the result data:
     - "vendor" - gets vendor from the result dict
@@ -37,21 +37,21 @@ class SetToHook(Hook):
 
     Examples:
         # Store complete result
-        set_to: "device_facts"
+        store_as: "device_facts"
 
         # Extract specific data (NO 'result.' prefix needed!)
-        set_to:
+        store_as:
           device_hostname: "hostname"
           device_vendor: "vendor"
           cpu_usage: "environment.cpu.0.%usage"
           task_failed: "_failed"
 
     Attributes:
-        hook_name: "set_to"
+        hook_name: "store_as"
         run_once_per_task: False (executes per host)
     """
 
-    hook_name = "set_to"
+    hook_name = "store_as"
     run_once_per_task = False
 
     def execute_hook_validations(self, task_model: "TaskModel") -> None:
@@ -68,15 +68,15 @@ class SetToHook(Hook):
         Raises:
             HookValidationError: If validation fails, with details on the specific issue.
         """
-        invalid_tasks = {"set", "echo", "set_to"}
+        invalid_tasks = {"set", "echo", "store_as"}
 
         if task_model.name in invalid_tasks:
             raise HookValidationError(
-                "SetToHook",
+                "StoreAsHook",
                 [
                     (
                         "task_compatibility",
-                        f"Hook 'SetToHook' cannot be used with task '{task_model.name}'. "
+                        f"Hook 'StoreAsHook' cannot be used with task '{task_model.name}'. "
                         f"Incompatible tasks: {invalid_tasks}",
                     )
                 ],
@@ -84,11 +84,11 @@ class SetToHook(Hook):
 
         if self.value is None:
             raise HookValidationError(
-                "SetToHook",
+                "StoreAsHook",
                 [
                     (
                         "value_required",
-                        "set_to hook requires a value (variable name or extraction specification)",
+                        "store_as hook requires a value (variable name or extraction specification)",
                     )
                 ],
             )
@@ -96,19 +96,19 @@ class SetToHook(Hook):
         if isinstance(self.value, str):
             if not self.value.strip():
                 raise HookValidationError(
-                    "SetToHook", [("empty_variable_name", "Variable name cannot be empty")]
+                    "StoreAsHook", [("empty_variable_name", "Variable name cannot be empty")]
                 )
         elif isinstance(self.value, dict):
             if not self.value:
                 raise HookValidationError(
-                    "SetToHook",
+                    "StoreAsHook",
                     [("empty_extraction_spec", "Extraction specification cannot be empty")],
                 )
 
             for var_name, extraction_path in self.value.items():
                 if not isinstance(var_name, str) or not var_name.strip():
                     raise HookValidationError(
-                        "SetToHook",
+                        "StoreAsHook",
                         [
                             (
                                 "invalid_variable_name",
@@ -119,7 +119,7 @@ class SetToHook(Hook):
 
                 if not isinstance(extraction_path, str) or not extraction_path.strip():
                     raise HookValidationError(
-                        "SetToHook",
+                        "StoreAsHook",
                         [
                             (
                                 "invalid_extraction_path",
@@ -129,11 +129,11 @@ class SetToHook(Hook):
                     )
         else:
             raise HookValidationError(
-                "SetToHook",
+                "StoreAsHook",
                 [
                     (
                         "invalid_value_type",
-                        f"set_to value must be a string or dict, got {type(self.value).__name__}",
+                        f"store_as value must be a string or dict, got {type(self.value).__name__}",
                     )
                 ],
             )
@@ -163,7 +163,7 @@ class SetToHook(Hook):
 
         vars_manager = self.context.get("vars_manager")
         if not vars_manager:
-            logger.warning(f"No vars_manager available for set_to hook on host '{host.name}'")
+            logger.warning(f"No vars_manager available for store_as hook on host '{host.name}'")
             return
 
         try:
@@ -199,7 +199,7 @@ class SetToHook(Hook):
                             f"on host '{host.name}': {e}"
                         )
         except Exception as e:
-            logger.exception(f"Error in set_to hook for host '{host.name}': {e}")
+            logger.exception(f"Error in store_as hook for host '{host.name}': {e}")
             raise
 
     def _extract_data_from_result(self, result: Result, extraction_path: str) -> Any:
@@ -231,7 +231,7 @@ class SetToHook(Hook):
 
             if current_obj is None:
                 raise HookValidationError(
-                    "SetToHook",
+                    "StoreAsHook",
                     [("null_result", f"Task result is None for extraction path '{extraction_path}'")],
                 )
 
@@ -242,7 +242,7 @@ class SetToHook(Hook):
             raise
         except Exception as e:
             raise HookValidationError(
-                "SetToHook", [("extraction_error", f"Failed to extract '{extraction_path}': {e}")]
+                "StoreAsHook", [("extraction_error", f"Failed to extract '{extraction_path}': {e}")]
             ) from e
 
     def _handle_special_prefixes(self, result: Result, extraction_path: str) -> Any | None:
@@ -271,7 +271,7 @@ class SetToHook(Hook):
         if not isinstance(current_obj, dict):
             available = self._get_available_keys(current_obj)
             raise HookValidationError(
-                "SetToHook",
+                "StoreAsHook",
                 [
                     (
                         "extraction_key_error",
@@ -289,7 +289,7 @@ class SetToHook(Hook):
 
         available = self._get_available_keys(current_obj)
         raise HookValidationError(
-            "SetToHook",
+            "StoreAsHook",
             [
                 (
                     "extraction_key_error",
@@ -310,7 +310,7 @@ class SetToHook(Hook):
             except Exception:
                 length = len(current_obj) if hasattr(current_obj, "__len__") else "unknown"
                 raise HookValidationError(
-                    "SetToHook",
+                    "StoreAsHook",
                     [
                         (
                             "extraction_index_error",

--- a/nornflow/builtins/hooks/store_as.py
+++ b/nornflow/builtins/hooks/store_as.py
@@ -6,7 +6,7 @@ from nornir.core.inventory import Host
 from nornir.core.task import MultiResult, Result, Task
 
 from nornflow.hooks import Hook
-from nornflow.hooks.exceptions import HookValidationError
+from nornflow.hooks.exceptions import HookError, HookValidationError
 from nornflow.logger import logger
 
 if TYPE_CHECKING:
@@ -18,38 +18,55 @@ class StoreAsHook(Hook):
     Store task execution results as runtime variables with optional data extraction.
 
     Captures task results and stores them in NornFlow's runtime variable system.
-    Supports both simple variable storage and selective data extraction from results.
+    Supports simple variable storage (task's returned 'Result.result') and selective extraction.
 
     Usage modes:
-    1. Simple: store_as: "var_name" - stores complete result object
-    2. Extraction: store_as: {var_name: "extraction_path"} - extracts specific data
+    1. Simple: store_as: "var_name" - stores the entire 'Result.result' in 'var_name'
+    2. Extraction: store_as: {var_name: "dotted.extraction.path"} - extracts specific nested data at 'dotted.extraction.path' into 'var_name'
 
-    For extraction paths, directly reference the keys in the result data:
-    - "vendor" - gets vendor from the result dict
-    - "hostname" - gets hostname from the result dict
+    Extraction root (first segment — the part before the first '.'):
+    - If it is a top-level attribute of Nornir's 'Result' (e.g. 'failed', 'changed', 'result'),
+      extraction starts on the 'Result' object at that attribute.
+    - Otherwise extraction starts at 'Result.result' and the full path applies (including that
+      first segment as a key into the task return value).
+
+    If extraction fails at any step (missing segment, bad index, null 'Result.result' when required),
+    the hook raises HookValidationError. That exception propagates uncaught and stops the workflow
+    at that point — it is not governed by failure strategy. Use valid, fully qualified paths.
+
+    To avoid ambiguity when a name exists on both 'Result' and inside 'Result.result', use a
+    fully qualified path from a top-level 'Result' attribute (e.g. 'result.vendor' for the
+    task return value, 'failed' for 'Result.failed').
+
+    For data in 'Result.result' (shorthand — first segment not on 'Result'):
+    - "vendor" - gets vendor from the task return value
+    - "hostname" - gets hostname from the task return value
     - "environment.cpu.usage" - nested dict access
     - "var_list[2]" - access indexes in lists
     - "dict.nested_list[1].another_dict.another_list[10]" - any combination of nested structures
-    - Special attributes from Result object:
-      - "_failed" - gets the failed boolean
-      - "_changed" - gets the changed boolean
-      - "_result" - gets the entire result data dict
+    - Wrapper attributes: "failed", "changed", "result", etc...
 
     Examples:
-        # Store complete result
+        # Shorthand for store_as: {device_facts: "result"} — stores 'Result.result' in 'device_facts'
         store_as: "device_facts"
 
-        # Extract specific data (NO 'result.' prefix needed!)
         store_as:
+          # Shorthand: 'hostname' is not on Result → lookup starts at 'Result.result'
           device_hostname: "hostname"
-          device_vendor: "vendor"
+
+          # 'Result.result' key 'vendor' (explicit via top-level 'result' attribute)
+          device_vendor: "result.vendor"
+
+          # nested value inside 'Result.result'. Here again, 'environment' is not on Result → lookup starts at 'Result.result'
           cpu_usage: "environment.cpu.0.%usage"
-          task_failed: "_failed"
+
+          # 'Result.failed' (first segment is a top-level Result attribute)
+          task_failed: "failed"
 
     Attributes:
         hook_name: "store_as"
         run_once_per_task: False (executes per host)
-    """
+    """  # noqa: E501
 
     hook_name = "store_as"
     run_once_per_task = False
@@ -153,90 +170,130 @@ class StoreAsHook(Hook):
             result: The MultiResult containing outcomes for all hosts.
 
         Raises:
+            HookError: If vars_manager is missing or no Result matches host in MultiResult.
+            HookValidationError: If extraction fails.
             Exception: Propagates any unhandled errors during processing.
         """
         if self.value is None or result is None:
             return
 
-        if result.failed:
-            return
-
         vars_manager = self.context.get("vars_manager")
         if not vars_manager:
-            logger.warning(f"No vars_manager available for store_as hook on host '{host.name}'")
-            return
+            raise HookError("store_as: Variables manager not available in hook context.")
 
         try:
+            # result is a per-host MultiResult (main task + subtasks), not all inventory hosts
             host_result = None
             for individual_result in result:
                 if individual_result.host.name == host.name:
                     host_result = individual_result
                     break
 
+            # Nornir inserts a Result before this callback — empty/no match should not happen in practice.
+            # if this ever triggers, suspect something is deeply wrong with execution context.
             if host_result is None:
-                logger.error(f"Could not find result for host '{host.name}' in MultiResult")
-                return
+                raise HookError(
+                    f"store_as: No Result for host '{host.name}' in MultiResult"
+                )
 
             if hasattr(host_result, "skipped") and host_result.skipped:
                 logger.debug(f"Host {host.name} was skipped by predicate, not setting variables")
                 return
 
+            # Simple mode: store_as: "var_name" — store Result.result directly (no path parsing).
+            # Equivalent to store_as: {var_name: "result"} but skips extraction machinery.
             if isinstance(self.value, str):
                 vars_manager.set_runtime_variable(self.value, host_result.result, host.name)
                 logger.debug(f"Stored result in variable '{self.value}' for host '{host.name}'")
+
+            # Extraction mode: store_as: {var_name: "dotted.path", ...} — one or more paths.
             else:
+                # (var_name, extraction_path) pairs whose first segment is a top-level
+                # attribute on Nornir's Result object (not inside Result.result)
+                # e.g. task_failed: "failed", full_return: "result", vendor: "result.vendor"
+                nornir_result_top_level_attr_items = []
+
+                # (var_name, extraction_path) pairs whose first segment is not on Result —
+                # shorthand paths; navigation starts at Result.result
+                # e.g. device_hostname: "hostname", cpu_usage: "environment.cpu.0.%usage"
+                shorthand_items = []
+
                 for var_name, extraction_path in self.value.items():
-                    try:
-                        extracted_value = self._extract_data_from_result(host_result, extraction_path)
-                        vars_manager.set_runtime_variable(var_name, extracted_value, host.name)
-                        logger.debug(
-                            f"Extracted '{extraction_path}' and stored as '{var_name}' "
-                            f"for host '{host.name}'"
-                        )
-                    except Exception as e:
-                        logger.exception(
-                            f"Failed to extract '{extraction_path}' for variable '{var_name}' "
-                            f"on host '{host.name}': {e}"
-                        )
+                    segments = self._parse_extraction_path(extraction_path)
+                    if (
+                        segments
+                        and segments[0]["type"] == "key"
+                        and hasattr(host_result, segments[0]["value"])
+                    ):
+                        nornir_result_top_level_attr_items.append((var_name, extraction_path))
+                    else:
+                        shorthand_items.append((var_name, extraction_path))
+
+                for var_name, extraction_path in nornir_result_top_level_attr_items + shorthand_items:
+                    extracted_value = self._extract_data_from_result(host_result, extraction_path)
+                    vars_manager.set_runtime_variable(var_name, extracted_value, host.name)
+                    logger.debug(
+                        f"Extracted '{extraction_path}' and stored as '{var_name}' "
+                        f"for host '{host.name}'"
+                    )
+
         except Exception as e:
             logger.exception(f"Error in store_as hook for host '{host.name}': {e}")
             raise
 
     def _extract_data_from_result(self, result: Result, extraction_path: str) -> Any:
         """
-        Extract data from Result object using dotted notation and bracket indexing.
+        Extract data from Result using hybrid root navigation and dotted/bracket paths.
 
-        Special prefixes:
-        - "_failed" - returns result.failed
-        - "_changed" - returns result.changed
-        - "_result" - returns the entire result.result dict
-        - Otherwise, extracts from result.result dict
+        If the first path segment is a 'Result' attribute, navigation starts there;
+        otherwise it starts at 'Result.result' (when the first segment is not on 'Result').
 
         Args:
-            result: The Result object to extract from
-            extraction_path: The path specification
+            result: The Result object to extract from.
+            extraction_path: The path specification.
 
         Returns:
-            The extracted data
+            The extracted data.
 
         Raises:
-            HookValidationError: If extraction fails
+            HookValidationError: If extraction fails.
         """
         try:
-            current_obj = self._handle_special_prefixes(result, extraction_path)
-            if current_obj is not None:
-                return current_obj
+            segments = self._parse_extraction_path(extraction_path)
+            if not segments:
+                raise HookValidationError(
+                    "StoreAsHook",
+                    [("invalid_extraction_path", f"Extraction path '{extraction_path}' is empty")],
+                )
 
-            current_obj = result.result
+            first = segments[0]
+            if first["type"] != "key":
+                raise HookValidationError(
+                    "StoreAsHook",
+                    [
+                        (
+                            "invalid_extraction_path",
+                            f"Extraction path '{extraction_path}' must start with a key segment",
+                        )
+                    ],
+                )
 
-            if current_obj is None:
+            name = first["value"]
+            rest = segments[1:]
+
+            # First segment names a top-level Result attribute — start there (e.g. "failed", "result.vendor").
+            if hasattr(result, name):
+                return self._extract_from_segments(getattr(result, name), rest, extraction_path)
+
+            # Shorthand path into Result.result, but the task returned nothing to traverse.
+            if result.result is None:
                 raise HookValidationError(
                     "StoreAsHook",
                     [("null_result", f"Task result is None for extraction path '{extraction_path}'")],
                 )
 
-            segments = self._parse_extraction_path(extraction_path)
-            return self._extract_from_segments(current_obj, segments, extraction_path)
+            # Shorthand: first segment is not on Result — traverse Result.result with the full path.
+            return self._extract_from_segments(result.result, segments, extraction_path)
 
         except HookValidationError:
             raise
@@ -244,16 +301,6 @@ class StoreAsHook(Hook):
             raise HookValidationError(
                 "StoreAsHook", [("extraction_error", f"Failed to extract '{extraction_path}': {e}")]
             ) from e
-
-    def _handle_special_prefixes(self, result: Result, extraction_path: str) -> Any | None:
-        """Handle special extraction path prefixes."""
-        if extraction_path == "_failed":
-            return result.failed
-        if extraction_path == "_changed":
-            return result.changed
-        if extraction_path == "_result":
-            return result.result
-        return None
 
     def _extract_from_segments(
         self, current_obj: Any, segments: list[dict[str, str]], extraction_path: str
@@ -267,25 +314,15 @@ class StoreAsHook(Hook):
         return current_obj
 
     def _handle_key_segment(self, current_obj: Any, key: str, extraction_path: str) -> Any:
-        """Handle key access for dict objects."""
-        if not isinstance(current_obj, dict):
-            available = self._get_available_keys(current_obj)
-            raise HookValidationError(
-                "StoreAsHook",
-                [
-                    (
-                        "extraction_key_error",
-                        f"Cannot access key '{key}' on non-dict object in path '{extraction_path}'. "
-                        f"Object type: {type(current_obj).__name__}. Available: {available}",
-                    )
-                ],
-            )
+        """Handle key access for dicts and object attributes."""
+        if isinstance(current_obj, dict):
+            if key in current_obj:
+                return current_obj[key]
 
-        if key in current_obj:
-            return current_obj[key]
-
-        if key.isdigit() and int(key) in current_obj:
-            return current_obj[int(key)]
+            if key.isdigit() and int(key) in current_obj:
+                return current_obj[int(key)]
+        elif hasattr(current_obj, key):
+            return getattr(current_obj, key)
 
         available = self._get_available_keys(current_obj)
         raise HookValidationError(
@@ -294,7 +331,7 @@ class StoreAsHook(Hook):
                 (
                     "extraction_key_error",
                     f"Key '{key}' not found in extraction path '{extraction_path}'. "
-                    f"Available: {available}",
+                    f"Object type: {type(current_obj).__name__}. Available: {available}",
                 )
             ],
         )

--- a/nornflow/builtins/hooks/store_as.py
+++ b/nornflow/builtins/hooks/store_as.py
@@ -1,6 +1,6 @@
 # ruff: noqa: PERF203
 
-from typing import Any, TYPE_CHECKING
+from typing import Any, NoReturn, TYPE_CHECKING
 
 from nornir.core.inventory import Host
 from nornir.core.task import MultiResult, Result, Task
@@ -11,6 +11,31 @@ from nornflow.logger import logger
 
 if TYPE_CHECKING:
     from nornflow.models import TaskModel
+
+_HOOK_CLASS = "StoreAsHook"
+_INCOMPATIBLE_TASKS = frozenset({"set", "echo", "store_as"})
+
+
+def _raise_validation(
+    error_code: str,
+    message: str,
+    *,
+    cause: BaseException | None = None,
+) -> NoReturn:
+    """Raise HookValidationError for StoreAsHook with a single coded error.
+
+    Args:
+        error_code: Short identifier for the validation failure.
+        message: Human-readable error detail.
+        cause: Optional exception to chain as ``__cause__``.
+
+    Raises:
+        HookValidationError: Always raised; this function never returns.
+    """
+    exc = HookValidationError(_HOOK_CLASS, [(error_code, message)])
+    if cause is not None:
+        raise exc from cause
+    raise exc
 
 
 class StoreAsHook(Hook):
@@ -85,74 +110,46 @@ class StoreAsHook(Hook):
         Raises:
             HookValidationError: If validation fails, with details on the specific issue.
         """
-        invalid_tasks = {"set", "echo", "store_as"}
+        invalid_tasks = _INCOMPATIBLE_TASKS
 
         if task_model.name in invalid_tasks:
-            raise HookValidationError(
-                "StoreAsHook",
-                [
-                    (
-                        "task_compatibility",
-                        f"Hook 'StoreAsHook' cannot be used with task '{task_model.name}'. "
-                        f"Incompatible tasks: {invalid_tasks}",
-                    )
-                ],
+            _raise_validation(
+                "task_compatibility",
+                f"Hook '{_HOOK_CLASS}' cannot be used with task '{task_model.name}'. "
+                f"Incompatible tasks: {invalid_tasks}",
             )
 
         if self.value is None:
-            raise HookValidationError(
-                "StoreAsHook",
-                [
-                    (
-                        "value_required",
-                        "store_as hook requires a value (variable name or extraction specification)",
-                    )
-                ],
+            _raise_validation(
+                "value_required",
+                "store_as hook requires a value (variable name or extraction specification)",
             )
 
         if isinstance(self.value, str):
             if not self.value.strip():
-                raise HookValidationError(
-                    "StoreAsHook", [("empty_variable_name", "Variable name cannot be empty")]
-                )
+                _raise_validation("empty_variable_name", "Variable name cannot be empty")
         elif isinstance(self.value, dict):
             if not self.value:
-                raise HookValidationError(
-                    "StoreAsHook",
-                    [("empty_extraction_spec", "Extraction specification cannot be empty")],
+                _raise_validation(
+                    "empty_extraction_spec", "Extraction specification cannot be empty"
                 )
 
             for var_name, extraction_path in self.value.items():
                 if not isinstance(var_name, str) or not var_name.strip():
-                    raise HookValidationError(
-                        "StoreAsHook",
-                        [
-                            (
-                                "invalid_variable_name",
-                                f"Variable name must be a non-empty string, got: {var_name}",
-                            )
-                        ],
+                    _raise_validation(
+                        "invalid_variable_name",
+                        f"Variable name must be a non-empty string, got: {var_name}",
                     )
 
                 if not isinstance(extraction_path, str) or not extraction_path.strip():
-                    raise HookValidationError(
-                        "StoreAsHook",
-                        [
-                            (
-                                "invalid_extraction_path",
-                                f"Extraction path for '{var_name}' must be a non-empty string",
-                            )
-                        ],
+                    _raise_validation(
+                        "invalid_extraction_path",
+                        f"Extraction path for '{var_name}' must be a non-empty string",
                     )
         else:
-            raise HookValidationError(
-                "StoreAsHook",
-                [
-                    (
-                        "invalid_value_type",
-                        f"store_as value must be a string or dict, got {type(self.value).__name__}",
-                    )
-                ],
+            _raise_validation(
+                "invalid_value_type",
+                f"store_as value must be a string or dict, got {type(self.value).__name__}",
             )
 
     def task_instance_completed(self, task: Task, host: Host, result: MultiResult) -> None:
@@ -261,21 +258,15 @@ class StoreAsHook(Hook):
         try:
             segments = self._parse_extraction_path(extraction_path)
             if not segments:
-                raise HookValidationError(
-                    "StoreAsHook",
-                    [("invalid_extraction_path", f"Extraction path '{extraction_path}' is empty")],
+                _raise_validation(
+                    "invalid_extraction_path", f"Extraction path '{extraction_path}' is empty"
                 )
 
             first = segments[0]
             if first["type"] != "key":
-                raise HookValidationError(
-                    "StoreAsHook",
-                    [
-                        (
-                            "invalid_extraction_path",
-                            f"Extraction path '{extraction_path}' must start with a key segment",
-                        )
-                    ],
+                _raise_validation(
+                    "invalid_extraction_path",
+                    f"Extraction path '{extraction_path}' must start with a key segment",
                 )
 
             name = first["value"]
@@ -287,9 +278,8 @@ class StoreAsHook(Hook):
 
             # Shorthand path into Result.result, but the task returned nothing to traverse.
             if result.result is None:
-                raise HookValidationError(
-                    "StoreAsHook",
-                    [("null_result", f"Task result is None for extraction path '{extraction_path}'")],
+                _raise_validation(
+                    "null_result", f"Task result is None for extraction path '{extraction_path}'"
                 )
 
             # Shorthand: first segment is not on Result — traverse Result.result with the full path.
@@ -298,9 +288,11 @@ class StoreAsHook(Hook):
         except HookValidationError:
             raise
         except Exception as e:
-            raise HookValidationError(
-                "StoreAsHook", [("extraction_error", f"Failed to extract '{extraction_path}': {e}")]
-            ) from e
+            _raise_validation(
+                "extraction_error",
+                f"Failed to extract '{extraction_path}': {e}",
+                cause=e,
+            )
 
     def _extract_from_segments(
         self, current_obj: Any, segments: list[dict[str, str]], extraction_path: str
@@ -325,15 +317,10 @@ class StoreAsHook(Hook):
             return getattr(current_obj, key)
 
         available = self._get_available_keys(current_obj)
-        raise HookValidationError(
-            "StoreAsHook",
-            [
-                (
-                    "extraction_key_error",
-                    f"Key '{key}' not found in extraction path '{extraction_path}'. "
-                    f"Object type: {type(current_obj).__name__}. Available: {available}",
-                )
-            ],
+        _raise_validation(
+            "extraction_key_error",
+            f"Key '{key}' not found in extraction path '{extraction_path}'. "
+            f"Object type: {type(current_obj).__name__}. Available: {available}",
         )
 
     def _handle_index_segment(self, current_obj: Any, index_str: str, extraction_path: str) -> Any:
@@ -346,16 +333,12 @@ class StoreAsHook(Hook):
                 return current_obj[index_str]
             except Exception:
                 length = len(current_obj) if hasattr(current_obj, "__len__") else "unknown"
-                raise HookValidationError(
-                    "StoreAsHook",
-                    [
-                        (
-                            "extraction_index_error",
-                            f"Index [{index_str}] not accessible in extraction path "
-                            f"'{extraction_path}'. Length: {length}",
-                        )
-                    ],
-                ) from e
+                _raise_validation(
+                    "extraction_index_error",
+                    f"Index [{index_str}] not accessible in extraction path "
+                    f"'{extraction_path}'. Length: {length}",
+                    cause=e,
+                )
 
     def _parse_extraction_path(self, path: str) -> list[dict[str, str]]:
         """

--- a/nornflow/builtins/hooks/store_as.py
+++ b/nornflow/builtins/hooks/store_as.py
@@ -1,4 +1,3 @@
-# ruff: noqa: PERF203
 
 from typing import Any, NoReturn, TYPE_CHECKING
 
@@ -152,7 +151,9 @@ class StoreAsHook(Hook):
                 f"store_as value must be a string or dict, got {type(self.value).__name__}",
             )
 
-    def task_instance_completed(self, task: Task, host: Host, result: MultiResult) -> None:
+    def task_instance_completed(  # noqa: PLR0912
+        self, task: Task, host: Host, result: MultiResult
+    ) -> None:
         """
         Process task results and store them as runtime variables for the host.
 

--- a/nornflow/nornflow.py
+++ b/nornflow/nornflow.py
@@ -82,7 +82,7 @@ class NornFlow:
     4. Default processor if none of the above are specified
 
     Variable precedence follows this order (highest to lowest priority):
-    1. Runtime Variables (dynamically set by the 'set' task or 'set_to' hook)
+    1. Runtime Variables (dynamically set by the 'set' task or 'store_as' hook)
     2. CLI Variables (passed via --vars option or set programmatically)
     3. Inline Workflow Variables (defined in workflow YAML under vars: section)
     4. Domain-specific Default Variables (from vars_dir/<domain>/defaults.yaml)

--- a/nornflow/vars/manager.py
+++ b/nornflow/vars/manager.py
@@ -109,7 +109,7 @@ class NornFlowVariablesManager:
     during workflow execution.
 
     NornFlow Default Namespace Variable Precedence (Highest to Lowest):
-    1. Runtime Variables (dynamically set by the 'set' task or 'set_to' keyword)
+    1. Runtime Variables (dynamically set by the 'set' task or 'store_as' keyword)
     2. CLI Variables
     3. Inline Workflow Variables (defined in the `workflow.vars` section)
     4. Domain-specific Default Variables (from `{vars_dir}/{domain}/defaults.yaml`)

--- a/tests/README.md
+++ b/tests/README.md
@@ -130,12 +130,34 @@ pytest tests/integration/containerlab \
 
 ### What the suite does
 
+The Layer 2 suite runs in **phases**. Each phase builds on the previous one:
+
+| Phase | What | Device I/O |
+|-------|------|------------|
+| **A** | Provision isolated venv + temp NornFlow project | No |
+| **B** | Catalog load + `nornflow show` smoke tests | No |
+| **C** | `nornflow run` workflows against live cEOS | Yes |
+| **D**,**E...** | Not implemented (see [Out of scope](#out-of-scope-v1)) | — |
+
+**Phase A — provision** (session fixture, once per pytest run):
+
 1. Creates a temp directory with its own virtualenv.
 2. Installs **editable nornflow** from your checkout and **pinned `nornflow-arista`** from PyPI (version from `constants.py`).
 3. Writes a minimal temp project with static Nornir inventory (four hosts, HTTP eAPI) from `LAB_HOSTS` in `constants.py`.
-4. **Phase B** — in-process catalog validation plus `nornflow show` for tasks, filters, workflows, blueprints, j2-filters, and hooks (no device I/O).
-5. **Phase C** — runs `nornflow run lab_integration.yaml`: plain workflow vars, package j2 filters in task args, builtin hooks (`if`, `single`, `set_to`), local blueprint with read-only package getters, and a final `get_facts` on all hosts.
-6. Deletes the temp tree when finished (pass or fail).
+
+Implemented in `provision_lab_environment()` (`lab_project.py`), triggered by the `lab_environment` session fixture.
+
+**Phase B — catalog smoke tests** (no device I/O):
+
+- In-process catalog validation via `lab_runner.py phase-b` (`test_catalog_and_package.py`).
+- `nornflow show` CLI checks for tasks, filters, workflows, blueprints, j2-filters, and hooks (`test_nornflow_show.py`).
+
+**Phase C — live workflow runs** (requires reachable lab):
+
+- `nornflow run lab_integration.yaml` — workflow vars, package j2 filters, hooks (`if`, `single`, `store_as`), local blueprint, read-only `get_facts` (`test_readonly_getters.py`).
+- `nornflow run lab_store_as_failure.yaml` — failure-path `store_as` + conditional echo (`test_store_as_failure_path.py`).
+
+**Teardown:** deletes the temp tree when the session finishes (pass or fail).
 
 ---
 
@@ -163,17 +185,23 @@ Reference inventory (no secrets): `tests/integration/containerlab/inventory/host
 - `NORNFLOW_LAB` is not `1` — expected for normal `pytest` / CI.
 - You ran without `--override-ini addopts=` and `-m containerlab` — default pytest excludes the `containerlab` marker.
 
+### Phase A fails (provision)
+
+- `uv venv` / `uv pip install` errors — check network access to PyPI and that `uv` is on your PATH.
+- PyPI or version pin issue installing `nornflow-arista` at the version in `constants.py`.
+- Failure writing the temp project under the session temp directory (permissions, disk space).
+
+### Phase B fails (catalog / show)
+
+- Package load or catalog resolution error — run with `-v` and inspect stderr from the lab venv subprocess.
+- Missing expected catalog keys in `test_catalog_and_package.py` or `test_nornflow_show.py` — often a breaking change in builtin or `nornflow-arista` asset names.
+
 ### Timeouts / connection failures (Phase C)
 
 - No route to the lab management subnet from the pytest host — fix routing, VPN, or port forwarding for your environment.
 - Lab not running or nodes still booting — confirm containers/VMs are up and eAPI is enabled.
 - Wrong credentials — verify with the curl preflight above.
 - **IP mismatch** — if your lab uses different addresses, update `LAB_HOSTS` in `constants.py` (see [Customizing the lab](#customizing-the-lab)).
-
-### Phase B fails
-
-- PyPI or network issue installing `nornflow-arista` at the version pinned in `constants.py`.
-- Package load error — run with `-v` and inspect stderr from the lab venv subprocess.
 
 ---
 

--- a/tests/README.md
+++ b/tests/README.md
@@ -143,7 +143,9 @@ The Layer 2 suite runs in **phases**. Each phase builds on the previous one:
 
 1. Creates a temp directory with its own virtualenv.
 2. Installs **editable nornflow** from your checkout and **pinned `nornflow-arista`** from PyPI (version from `constants.py`).
-3. Writes a minimal temp project with static Nornir inventory (four hosts, HTTP eAPI) from `LAB_HOSTS` in `constants.py`.
+3. Runs **`nornflow init`** in the temp project, merges **static fixture assets** from `tests/integration/fixtures/common/` and `tests/integration/containerlab/fixtures/overlay/`, patches `nornflow.yaml` (e.g. `packages`), and writes **hosts.yaml** with credentials from env vars.
+
+Review workflows, blueprints, vars, and j2 filters in those fixture directories — they are copied verbatim into the temp project (not built from Python strings).
 
 Implemented in `provision_lab_environment()` (`lab_project.py`), triggered by the `lab_environment` session fixture.
 
@@ -151,6 +153,7 @@ Implemented in `provision_lab_environment()` (`lab_project.py`), triggered by th
 
 - In-process catalog validation via `lab_runner.py phase-b` (`test_catalog_and_package.py`).
 - `nornflow show` CLI checks for tasks, filters, workflows, blueprints, j2-filters, and hooks (`test_nornflow_show.py`).
+- `nornflow run vars_all_levels.yaml` — env, global, domain, workflow, CLI, and runtime vars plus j2 filters (`test_vars_all_levels.py`, echo-only; file under `workflows/lab/` for domain scoping).
 
 **Phase C — live workflow runs** (requires reachable lab):
 

--- a/tests/integration/containerlab/conftest.py
+++ b/tests/integration/containerlab/conftest.py
@@ -45,7 +45,7 @@ def _require_lab_credentials() -> tuple[str, str]:
 
 @pytest.fixture(scope="session")
 def lab_environment(tmp_path_factory: pytest.TempPathFactory) -> Iterator[LabEnvironment]:
-    """Provision an isolated venv + temp project; tear down after the session.
+    """Phase A: provision isolated venv + temp project; tear down after the session.
 
     Yields:
         LabEnvironment with venv, project paths, and lab_runner location.

--- a/tests/integration/containerlab/constants.py
+++ b/tests/integration/containerlab/constants.py
@@ -23,6 +23,8 @@ NORNFLOW_ARISTA_VERSION = "0.1.0"
 
 # Generated local workflow and blueprint filenames (under temp project).
 LAB_INTEGRATION_WORKFLOW = "lab_integration.yaml"
+LAB_STORE_AS_FAILURE_WORKFLOW = "lab_store_as_failure.yaml"
+LAB_STORE_AS_FAILURE_MARKER = "NORNFLOW_LAB_STORE_AS_FAILURE_OK"
 LAB_READONLY_BLUEPRINT = "lab_readonly_snapshot.yaml"
 
 # Default four-node spine–leaf topology (management IPs or DNS names).

--- a/tests/integration/containerlab/constants.py
+++ b/tests/integration/containerlab/constants.py
@@ -21,11 +21,17 @@ class LabHostSpec(TypedDict):
 NORNFLOW_ARISTA_PACKAGE = "nornflow_arista"
 NORNFLOW_ARISTA_VERSION = "0.1.0"
 
-# Generated local workflow and blueprint filenames (under temp project).
+# Static fixture asset filenames (under tests/integration/containerlab/fixtures/overlay/).
 LAB_INTEGRATION_WORKFLOW = "lab_integration.yaml"
 LAB_STORE_AS_FAILURE_WORKFLOW = "lab_store_as_failure.yaml"
 LAB_STORE_AS_FAILURE_MARKER = "NORNFLOW_LAB_STORE_AS_FAILURE_OK"
 LAB_READONLY_BLUEPRINT = "lab_readonly_snapshot.yaml"
+# File lives under workflows/lab/ for domain vars; catalog key is the filename only.
+LAB_VARS_ALL_LEVELS_WORKFLOW = "vars_all_levels.yaml"
+
+# Env var name set at test runtime for vars-all-levels workflow (NORNFLOW_VAR_env_marker).
+LAB_VARS_ENV_VAR = "env_marker"
+LAB_VARS_ENV_VALUE = "ENV_OK"
 
 # Default four-node spine–leaf topology (management IPs or DNS names).
 LAB_HOSTS: dict[str, LabHostSpec] = {

--- a/tests/integration/containerlab/fixtures/overlay/blueprints/lab_readonly_snapshot.yaml
+++ b/tests/integration/containerlab/fixtures/overlay/blueprints/lab_readonly_snapshot.yaml
@@ -1,0 +1,14 @@
+description: >
+  Read-only snapshot for containerlab: version facts and LLDP neighbors.
+  Uses store_as to store results in runtime variables.
+
+tasks:
+  - name: nornflow_arista.get_facts
+    store_as:
+      facts: result
+
+  - name: nornflow_arista.get_lldp_neighbors
+    args:
+      detail: true
+    store_as:
+      lldp_neighbors: result

--- a/tests/integration/containerlab/fixtures/overlay/j2_filters/lab_prefix.py
+++ b/tests/integration/containerlab/fixtures/overlay/j2_filters/lab_prefix.py
@@ -1,0 +1,14 @@
+"""Local Jinja2 filter used by containerlab var-level integration workflows."""
+
+
+def lab_prefix(value: str, prefix: str = "LAB") -> str:
+    """Return value prefixed for lab assertions.
+
+    Args:
+        value: Input string from a template.
+        prefix: Prefix to prepend.
+
+    Returns:
+        ``{prefix}:{value}`` string.
+    """
+    return f"{prefix}:{value}"

--- a/tests/integration/containerlab/fixtures/overlay/nornir_configs/groups.yaml
+++ b/tests/integration/containerlab/fixtures/overlay/nornir_configs/groups.yaml
@@ -1,0 +1,3 @@
+eos: {}
+spines: {}
+leafs: {}

--- a/tests/integration/containerlab/fixtures/overlay/vars/defaults.yaml
+++ b/tests/integration/containerlab/fixtures/overlay/vars/defaults.yaml
@@ -1,0 +1,2 @@
+global_marker: GLOBAL_OK
+override_var: GLOBAL_OK

--- a/tests/integration/containerlab/fixtures/overlay/vars/lab/defaults.yaml
+++ b/tests/integration/containerlab/fixtures/overlay/vars/lab/defaults.yaml
@@ -1,0 +1,2 @@
+domain_marker: DOMAIN_OK
+override_var: DOMAIN_OK

--- a/tests/integration/containerlab/fixtures/overlay/workflows/lab/vars_all_levels.yaml
+++ b/tests/integration/containerlab/fixtures/overlay/workflows/lab/vars_all_levels.yaml
@@ -1,0 +1,29 @@
+workflow:
+  name: Lab vars all levels
+  description: >
+    Echo workflow exercising environment, global, domain, workflow, CLI, and runtime
+    variable sources plus package, builtin, and local Jinja2 filters.
+  vars:
+    workflow_marker: WORKFLOW_OK
+    override_var: WORKFLOW_OK
+    cli_marker: UNSET
+  tasks:
+    - name: nornflow.set
+      args:
+        runtime_marker: RUNTIME_OK
+        override_var: RUNTIME_OK
+
+    - name: nornflow.echo
+      args:
+        msg: >-
+          env={{ env_marker }}
+          global={{ global_marker }}
+          domain={{ domain_marker }}
+          workflow={{ workflow_marker }}
+          cli={{ cli_marker }}
+          runtime={{ runtime_marker }}
+          override={{ override_var }}
+          host={{ host.name }}
+          j2_package={{ '10,20' | nornflow_arista.eos_vlan_expand | join('-') }}
+          j2_builtin={{ 'runtime_marker' | is_set }}
+          j2_local={{ 'vars' | lab_prefix }}

--- a/tests/integration/containerlab/fixtures/overlay/workflows/lab_integration.yaml
+++ b/tests/integration/containerlab/fixtures/overlay/workflows/lab_integration.yaml
@@ -1,0 +1,28 @@
+workflow:
+  name: Containerlab integration workflow
+  description: >
+    Exercises workflow vars, package j2 filters, builtin hooks (if, single, store_as),
+    a local blueprint, and read-only nornflow_arista tasks against live cEOS.
+  vars:
+    lab_active: true
+  tasks:
+    - name: nornflow.echo
+      args:
+        msg: >-
+          {{ host.name }}: vlans={{ '10,20-22' | nornflow_arista.eos_vlan_expand | join(',') }}
+          intf={{ 'gi0/1' | nornflow_arista.eos_intf_canonical }}
+      if: "{{ lab_active }}"
+
+    - blueprint: lab_readonly_snapshot.yaml
+      single: true
+
+    - name: nornflow.set
+      args:
+        lab_checked: "{{ host.name }}-ok"
+        lab_vlans: "{{ '10,20-22' | nornflow_arista.eos_vlan_expand | join(',') }}"
+      if: "{{ lab_active }}"
+
+    - name: nornflow_arista.get_facts
+      store_as:
+        final_facts: result
+      if: "{{ lab_active }}"

--- a/tests/integration/containerlab/fixtures/overlay/workflows/lab_store_as_failure.yaml
+++ b/tests/integration/containerlab/fixtures/overlay/workflows/lab_store_as_failure.yaml
@@ -1,0 +1,16 @@
+workflow:
+  name: Containerlab store_as failure path
+  failure_strategy: run-all
+  tasks:
+    - name: nornflow.write_file
+      args:
+        filename: ""
+        content: "x"
+      store_as:
+        step_failed: failed
+
+    - name: nornflow.echo
+      if: "{{ step_failed }}"
+      args:
+        msg: "NORNFLOW_LAB_STORE_AS_FAILURE_OK"
+      store_as: rollback_msg

--- a/tests/integration/containerlab/lab_project.py
+++ b/tests/integration/containerlab/lab_project.py
@@ -13,6 +13,8 @@ from tests.integration.containerlab.constants import (
     LAB_HOSTS,
     LAB_INTEGRATION_WORKFLOW,
     LAB_READONLY_BLUEPRINT,
+    LAB_STORE_AS_FAILURE_MARKER,
+    LAB_STORE_AS_FAILURE_WORKFLOW,
     NORNFLOW_ARISTA_PACKAGE,
     NORNFLOW_ARISTA_VERSION,
 )
@@ -194,6 +196,41 @@ workflow:
     return workflow_file
 
 
+def _write_lab_store_as_failure_workflow(project_root: Path) -> Path:
+    """Write a workflow that fails step 1 and conditionally echoes via store_as.
+
+    Args:
+        project_root: Root of the generated project.
+
+    Returns:
+        Path to the failure-path workflow YAML file.
+    """
+    workflows_dir = project_root / "workflows"
+    workflows_dir.mkdir(parents=True, exist_ok=True)
+    workflow_file = workflows_dir / LAB_STORE_AS_FAILURE_WORKFLOW
+    workflow_file.write_text(
+        """\
+workflow:
+  name: Containerlab store_as failure path
+  failure_strategy: run-all
+
+  tasks:
+    - name: nornflow.write_file
+      args:
+        filename: ""
+        content: "x"
+      store_as:
+        step_failed: failed
+
+    - name: nornflow.echo
+      if: "{{ step_failed }}"
+      args:
+        msg: """
+        + f'"{LAB_STORE_AS_FAILURE_MARKER}"\n'
+    )
+    return workflow_file
+
+
 def _write_nornflow_settings(project_root: Path, nornir_config_file: Path) -> Path:
     """Write nornflow.yaml for a package-only temp project.
 
@@ -239,6 +276,7 @@ def build_lab_project(project_root: Path, username: str, password: str) -> Path:
     _write_hosts_yaml(project_root / "nornir_configs" / "inventory" / "hosts.yaml", username, password)
     _write_local_blueprint(project_root)
     _write_lab_integration_workflow(project_root)
+    _write_lab_store_as_failure_workflow(project_root)
     return _write_nornflow_settings(project_root, config_file)
 
 

--- a/tests/integration/containerlab/lab_project.py
+++ b/tests/integration/containerlab/lab_project.py
@@ -297,7 +297,7 @@ def _run_command(args: list[str], *, cwd: Path | None = None) -> None:
 
 
 def provision_lab_environment(root: Path, username: str, password: str) -> LabEnvironment:
-    """Create venv, install packages, and write the temp NornFlow project.
+    """Phase A: create venv, install packages, and write the temp NornFlow project.
 
     Args:
         root: Session temp directory.

--- a/tests/integration/containerlab/lab_project.py
+++ b/tests/integration/containerlab/lab_project.py
@@ -133,13 +133,13 @@ description: >
 tasks:
   - name: nornflow_arista.get_facts
     store_as:
-      facts: "_result"
+      facts: result
 
   - name: nornflow_arista.get_lldp_neighbors
     args:
       detail: true
     store_as:
-      lldp_neighbors: "_result"
+      lldp_neighbors: result
 """
     )
     return blueprint_file
@@ -187,7 +187,7 @@ workflow:
 
     - name: nornflow_arista.get_facts
       store_as:
-        final_facts: "_result"
+        final_facts: result
       if: "{{ lab_active }}"
 """
     )

--- a/tests/integration/containerlab/lab_project.py
+++ b/tests/integration/containerlab/lab_project.py
@@ -11,13 +11,15 @@ from tests.integration.containerlab.constants import (
     LAB_EAPI_PORT,
     LAB_EAPI_TRANSPORT,
     LAB_HOSTS,
-    LAB_INTEGRATION_WORKFLOW,
-    LAB_READONLY_BLUEPRINT,
-    LAB_STORE_AS_FAILURE_MARKER,
-    LAB_STORE_AS_FAILURE_WORKFLOW,
     NORNFLOW_ARISTA_PACKAGE,
     NORNFLOW_ARISTA_VERSION,
 )
+from tests.integration.project_bootstrap import (
+    FIXTURES_COMMON,
+    bootstrap_nornflow_project,
+)
+
+CONTAINERLAB_OVERLAY = Path(__file__).resolve().parent / "fixtures" / "overlay"
 
 
 @dataclass(frozen=True)
@@ -48,8 +50,8 @@ def repo_root() -> Path:
     return Path(__file__).resolve().parents[3]
 
 
-def _write_hosts_yaml(path: Path, username: str, password: str) -> None:
-    """Write static Nornir hosts with eAPI connection data.
+def write_lab_hosts_yaml(path: Path, username: str, password: str) -> None:
+    """Write Nornir hosts with eAPI connection data from LAB_HOSTS.
 
     Args:
         path: Destination hosts.yaml path.
@@ -71,213 +73,30 @@ def _write_hosts_yaml(path: Path, username: str, password: str) -> None:
     path.write_text(yaml.safe_dump(hosts, sort_keys=True))
 
 
-def _write_nornir_tree(project_root: Path) -> Path:
-    """Write Nornir config and inventory under nornir_configs/.
+def build_lab_project(
+    project_root: Path,
+    nornflow_cli: Path,
+    username: str,
+    password: str,
+) -> Path:
+    """Create the on-disk NornFlow project via init, fixtures, and hosts injection.
 
     Args:
-        project_root: Root of the generated project.
-
-    Returns:
-        Path to config.yaml.
-    """
-    config_dir = project_root / "nornir_configs"
-    inventory_dir = config_dir / "inventory"
-    inventory_dir.mkdir(parents=True, exist_ok=True)
-
-    (inventory_dir / "groups.yaml").write_text(
-        yaml.safe_dump(
-            {
-                "eos": {},
-                "spines": {},
-                "leafs": {},
-            },
-            sort_keys=True,
-        )
-    )
-    (inventory_dir / "defaults.yaml").write_text("{}\n")
-
-    config_file = config_dir / "config.yaml"
-    config_file.write_text(
-        """\
-inventory:
-  plugin: SimpleInventory
-  options:
-    host_file: 'nornir_configs/inventory/hosts.yaml'
-    group_file: 'nornir_configs/inventory/groups.yaml'
-    defaults_file: 'nornir_configs/inventory/defaults.yaml'
-runner:
-  plugin: threaded
-  options:
-    num_workers: 4
-"""
-    )
-    return config_file
-
-
-def _write_local_blueprint(project_root: Path) -> Path:
-    """Write a minimal local blueprint using package read-only getters.
-
-    Args:
-        project_root: Root of the generated project.
-
-    Returns:
-        Path to the blueprint YAML file.
-    """
-    blueprints_dir = project_root / "blueprints"
-    blueprints_dir.mkdir(parents=True, exist_ok=True)
-    blueprint_file = blueprints_dir / LAB_READONLY_BLUEPRINT
-    blueprint_file.write_text(
-        """\
-description: >
-  Read-only snapshot for containerlab: version facts and LLDP neighbors.
-  Uses store_as to store results in runtime variables.
-
-tasks:
-  - name: nornflow_arista.get_facts
-    store_as:
-      facts: result
-
-  - name: nornflow_arista.get_lldp_neighbors
-    args:
-      detail: true
-    store_as:
-      lldp_neighbors: result
-"""
-    )
-    return blueprint_file
-
-
-def _write_lab_integration_workflow(project_root: Path) -> Path:
-    """Write a workflow exercising vars, j2 filters, hooks, and a local blueprint.
-
-    Args:
-        project_root: Root of the generated project.
-
-    Returns:
-        Path to the workflow YAML file.
-    """
-    workflows_dir = project_root / "workflows"
-    workflows_dir.mkdir(parents=True, exist_ok=True)
-    workflow_file = workflows_dir / LAB_INTEGRATION_WORKFLOW
-    workflow_file.write_text(
-        """\
-workflow:
-  name: Containerlab integration workflow
-  description: >
-    Exercises workflow vars, package j2 filters, builtin hooks (if, single, store_as),
-    a local blueprint, and read-only nornflow_arista tasks against live cEOS.
-  vars:
-    lab_active: true
-  tasks:
-    - name: nornflow.echo
-      args:
-        msg: >-
-          {{ host.name }}: vlans={{ '10,20-22' | nornflow_arista.eos_vlan_expand | join(',') }}
-          intf={{ 'gi0/1' | nornflow_arista.eos_intf_canonical }}
-      if: "{{ lab_active }}"
-
-    - blueprint: """
-        + LAB_READONLY_BLUEPRINT
-        + """
-      single: true
-
-    - name: nornflow.set
-      args:
-        lab_checked: "{{ host.name }}-ok"
-        lab_vlans: "{{ '10,20-22' | nornflow_arista.eos_vlan_expand | join(',') }}"
-      if: "{{ lab_active }}"
-
-    - name: nornflow_arista.get_facts
-      store_as:
-        final_facts: result
-      if: "{{ lab_active }}"
-"""
-    )
-    return workflow_file
-
-
-def _write_lab_store_as_failure_workflow(project_root: Path) -> Path:
-    """Write a workflow that fails step 1 and conditionally echoes via store_as.
-
-    Args:
-        project_root: Root of the generated project.
-
-    Returns:
-        Path to the failure-path workflow YAML file.
-    """
-    workflows_dir = project_root / "workflows"
-    workflows_dir.mkdir(parents=True, exist_ok=True)
-    workflow_file = workflows_dir / LAB_STORE_AS_FAILURE_WORKFLOW
-    workflow_file.write_text(
-        """\
-workflow:
-  name: Containerlab store_as failure path
-  failure_strategy: run-all
-
-  tasks:
-    - name: nornflow.write_file
-      args:
-        filename: ""
-        content: "x"
-      store_as:
-        step_failed: failed
-
-    - name: nornflow.echo
-      if: "{{ step_failed }}"
-      args:
-        msg: """
-        + f'"{LAB_STORE_AS_FAILURE_MARKER}"\n'
-    )
-    return workflow_file
-
-
-def _write_nornflow_settings(project_root: Path, nornir_config_file: Path) -> Path:
-    """Write nornflow.yaml for a package-only temp project.
-
-    Args:
-        project_root: Root of the generated project.
-        nornir_config_file: Path to the Nornir config file.
-
-    Returns:
-        Path to nornflow.yaml.
-    """
-    settings_file = project_root / "nornflow.yaml"
-    settings = {
-        "nornir_config_file": str(nornir_config_file.relative_to(project_root)),
-        "packages": [NORNFLOW_ARISTA_PACKAGE],
-        "local_tasks": [],
-        "local_workflows": ["workflows"],
-        "local_filters": [],
-        "local_hooks": [],
-        "local_blueprints": ["blueprints"],
-        "local_j2_filters": [],
-        "logger": {
-            "directory": ".nornflow/logs",
-            "level": "INFO",
-        },
-    }
-    settings_file.write_text(yaml.safe_dump(settings, sort_keys=True))
-    return settings_file
-
-
-def build_lab_project(project_root: Path, username: str, password: str) -> Path:
-    """Create the on-disk NornFlow project layout.
-
-    Args:
-        project_root: Directory where nornflow.yaml and Nornir files are written.
+        project_root: Directory where the project is created.
+        nornflow_cli: nornflow CLI from the lab venv.
         username: Device login user.
         password: Device login password.
 
     Returns:
-        Path to the generated nornflow.yaml file.
+        Path to nornflow.yaml.
     """
-    project_root.mkdir(parents=True, exist_ok=True)
-    config_file = _write_nornir_tree(project_root)
-    _write_hosts_yaml(project_root / "nornir_configs" / "inventory" / "hosts.yaml", username, password)
-    _write_local_blueprint(project_root)
-    _write_lab_integration_workflow(project_root)
-    _write_lab_store_as_failure_workflow(project_root)
-    return _write_nornflow_settings(project_root, config_file)
+    return bootstrap_nornflow_project(
+        project_root,
+        nornflow_executable=nornflow_cli,
+        overlay_dirs=[FIXTURES_COMMON, CONTAINERLAB_OVERLAY],
+        settings_patch={"packages": [NORNFLOW_ARISTA_PACKAGE]},
+        write_hosts=lambda hosts_path: write_lab_hosts_yaml(hosts_path, username, password),
+    )
 
 
 def _run_command(args: list[str], *, cwd: Path | None = None) -> None:
@@ -297,7 +116,7 @@ def _run_command(args: list[str], *, cwd: Path | None = None) -> None:
 
 
 def provision_lab_environment(root: Path, username: str, password: str) -> LabEnvironment:
-    """Phase A: create venv, install packages, and write the temp NornFlow project.
+    """Phase A: create venv, install packages, and bootstrap the temp NornFlow project.
 
     Args:
         root: Session temp directory.
@@ -314,6 +133,7 @@ def provision_lab_environment(root: Path, username: str, password: str) -> LabEn
 
     _run_command(["uv", "venv", str(venv_dir)])
     python = venv_dir / "bin" / "python"
+    nornflow_cli = venv_dir / "bin" / "nornflow"
     _run_command(
         [
             "uv",
@@ -327,7 +147,7 @@ def provision_lab_environment(root: Path, username: str, password: str) -> LabEn
         ]
     )
 
-    settings_file = build_lab_project(project_root, username, password)
+    settings_file = build_lab_project(project_root, nornflow_cli, username, password)
 
     return LabEnvironment(
         root=root,
@@ -335,7 +155,7 @@ def provision_lab_environment(root: Path, username: str, password: str) -> LabEn
         project_root=project_root,
         settings_file=settings_file,
         python=python,
-        nornflow_cli=venv_dir / "bin" / "nornflow",
+        nornflow_cli=nornflow_cli,
         runner_script=runner_script,
     )
 

--- a/tests/integration/containerlab/lab_project.py
+++ b/tests/integration/containerlab/lab_project.py
@@ -128,17 +128,17 @@ def _write_local_blueprint(project_root: Path) -> Path:
         """\
 description: >
   Read-only snapshot for containerlab: version facts and LLDP neighbors.
-  Uses set_to to store results in runtime variables.
+  Uses store_as to store results in runtime variables.
 
 tasks:
   - name: nornflow_arista.get_facts
-    set_to:
+    store_as:
       facts: "_result"
 
   - name: nornflow_arista.get_lldp_neighbors
     args:
       detail: true
-    set_to:
+    store_as:
       lldp_neighbors: "_result"
 """
     )
@@ -162,7 +162,7 @@ def _write_lab_integration_workflow(project_root: Path) -> Path:
 workflow:
   name: Containerlab integration workflow
   description: >
-    Exercises workflow vars, package j2 filters, builtin hooks (if, single, set_to),
+    Exercises workflow vars, package j2 filters, builtin hooks (if, single, store_as),
     a local blueprint, and read-only nornflow_arista tasks against live cEOS.
   vars:
     lab_active: true
@@ -186,7 +186,7 @@ workflow:
       if: "{{ lab_active }}"
 
     - name: nornflow_arista.get_facts
-      set_to:
+      store_as:
         final_facts: "_result"
       if: "{{ lab_active }}"
 """

--- a/tests/integration/containerlab/lab_runner.py
+++ b/tests/integration/containerlab/lab_runner.py
@@ -13,6 +13,7 @@ from tests.integration.containerlab.constants import (
     LAB_INTEGRATION_WORKFLOW,
     LAB_READONLY_BLUEPRINT,
     LAB_STORE_AS_FAILURE_WORKFLOW,
+    LAB_VARS_ALL_LEVELS_WORKFLOW,
     NORNFLOW_ARISTA_PACKAGE,
 )
 
@@ -46,6 +47,7 @@ def run_phase_b(settings_file: Path) -> None:
     workflows = nornflow.workflows_catalog
     _assert_key(workflows, f"local.{LAB_INTEGRATION_WORKFLOW}", "workflows")
     _assert_key(workflows, f"local.{LAB_STORE_AS_FAILURE_WORKFLOW}", "workflows")
+    _assert_key(workflows, f"local.{LAB_VARS_ALL_LEVELS_WORKFLOW}", "workflows")
     _assert_key(workflows, f"{NORNFLOW_ARISTA_PACKAGE}.daily_snapshot.yaml", "workflows")
 
     blueprints = nornflow.blueprints_catalog
@@ -55,7 +57,9 @@ def run_phase_b(settings_file: Path) -> None:
     j2_catalog = nornflow.j2_filters_catalog
     _assert_key(j2_catalog, f"{NORNFLOW_ARISTA_PACKAGE}.eos_vlan_expand", "j2_filters")
     _assert_key(j2_catalog, f"{NORNFLOW_ARISTA_PACKAGE}.eos_intf_canonical", "j2_filters")
+    _assert_key(j2_catalog, "local.lab_prefix", "j2_filters")
     j2_catalog.resolve("nornflow_arista.eos_vlan_expand")
+    j2_catalog.resolve("local.lab_prefix")
 
     for hook_name in ("if", "single", "store_as"):
         _assert_key(HOOKS_CATALOG, f"{BUILTIN_NAMESPACE}.{hook_name}", "hooks")

--- a/tests/integration/containerlab/lab_runner.py
+++ b/tests/integration/containerlab/lab_runner.py
@@ -12,6 +12,7 @@ from nornflow.settings import NornFlowSettings
 from tests.integration.containerlab.constants import (
     LAB_INTEGRATION_WORKFLOW,
     LAB_READONLY_BLUEPRINT,
+    LAB_STORE_AS_FAILURE_WORKFLOW,
     NORNFLOW_ARISTA_PACKAGE,
 )
 
@@ -44,6 +45,7 @@ def run_phase_b(settings_file: Path) -> None:
 
     workflows = nornflow.workflows_catalog
     _assert_key(workflows, f"local.{LAB_INTEGRATION_WORKFLOW}", "workflows")
+    _assert_key(workflows, f"local.{LAB_STORE_AS_FAILURE_WORKFLOW}", "workflows")
     _assert_key(workflows, f"{NORNFLOW_ARISTA_PACKAGE}.daily_snapshot.yaml", "workflows")
 
     blueprints = nornflow.blueprints_catalog

--- a/tests/integration/containerlab/lab_runner.py
+++ b/tests/integration/containerlab/lab_runner.py
@@ -55,7 +55,7 @@ def run_phase_b(settings_file: Path) -> None:
     _assert_key(j2_catalog, f"{NORNFLOW_ARISTA_PACKAGE}.eos_intf_canonical", "j2_filters")
     j2_catalog.resolve("nornflow_arista.eos_vlan_expand")
 
-    for hook_name in ("if", "single", "set_to"):
+    for hook_name in ("if", "single", "store_as"):
         _assert_key(HOOKS_CATALOG, f"{BUILTIN_NAMESPACE}.{hook_name}", "hooks")
 
     print(

--- a/tests/integration/containerlab/test_nornflow_show.py
+++ b/tests/integration/containerlab/test_nornflow_show.py
@@ -41,7 +41,7 @@ def _combined_output(result: subprocess.CompletedProcess[str]) -> str:
         ),
         (
             ["show", "--hooks"],
-            ["nornflow.if", "nornflow.single", "nornflow.set_to"],
+            ["nornflow.if", "nornflow.single", "nornflow.store_as"],
         ),
     ],
 )

--- a/tests/integration/containerlab/test_nornflow_show.py
+++ b/tests/integration/containerlab/test_nornflow_show.py
@@ -8,6 +8,8 @@ from tests.integration.containerlab.conftest import run_nornflow_cli
 from tests.integration.containerlab.constants import (
     LAB_INTEGRATION_WORKFLOW,
     LAB_READONLY_BLUEPRINT,
+    LAB_STORE_AS_FAILURE_WORKFLOW,
+    LAB_VARS_ALL_LEVELS_WORKFLOW,
 )
 from tests.integration.containerlab.lab_project import LabEnvironment
 
@@ -29,7 +31,12 @@ def _combined_output(result: subprocess.CompletedProcess[str]) -> str:
         ),
         (
             ["show", "--workflows"],
-            [LAB_INTEGRATION_WORKFLOW, "nornflow_arista.daily_snapshot.yaml"],
+            [
+                LAB_INTEGRATION_WORKFLOW,
+                LAB_STORE_AS_FAILURE_WORKFLOW,
+                LAB_VARS_ALL_LEVELS_WORKFLOW,
+                "nornflow_arista.daily_snapshot.yaml",
+            ],
         ),
         (
             ["show", "--blueprints"],
@@ -37,7 +44,11 @@ def _combined_output(result: subprocess.CompletedProcess[str]) -> str:
         ),
         (
             ["show", "--j2-filters"],
-            ["nornflow_arista.eos_vlan_expand", "nornflow_arista.eos_intf_canonical"],
+            [
+                "nornflow_arista.eos_vlan_expand",
+                "nornflow_arista.eos_intf_canonical",
+                "local.lab_prefix",
+            ],
         ),
         (
             ["show", "--hooks"],

--- a/tests/integration/containerlab/test_readonly_getters.py
+++ b/tests/integration/containerlab/test_readonly_getters.py
@@ -5,6 +5,6 @@ from tests.integration.containerlab.lab_project import LabEnvironment
 
 
 def test_integration_workflow_on_live_lab(lab_environment: LabEnvironment) -> None:
-    """lab_integration.yaml runs echo, blueprint (single+set_to), set, and get_facts on cEOS."""
+    """lab_integration.yaml runs echo, blueprint (single+store_as), set, and get_facts on cEOS."""
     result = run_lab_workflow(lab_environment)
     assert result.returncode == 0, "nornflow run lab_integration.yaml failed (see output above)"

--- a/tests/integration/containerlab/test_store_as_failure_path.py
+++ b/tests/integration/containerlab/test_store_as_failure_path.py
@@ -1,0 +1,23 @@
+"""Phase C: store_as failure-path workflow (write_file fails, conditional echo follows)."""
+
+from tests.integration.containerlab.conftest import run_nornflow_cli
+from tests.integration.containerlab.constants import (
+    LAB_STORE_AS_FAILURE_MARKER,
+    LAB_STORE_AS_FAILURE_WORKFLOW,
+)
+from tests.integration.containerlab.lab_project import LabEnvironment
+
+
+def test_store_as_stores_failed_flag_and_enables_conditional_followup(
+    lab_environment: LabEnvironment,
+) -> None:
+    """store_as captures Result.failed on failure; if-hook echo proves the var is set."""
+    result = run_nornflow_cli(
+        lab_environment,
+        ["run", LAB_STORE_AS_FAILURE_WORKFLOW],
+        stream=False,
+    )
+    output = f"{result.stdout or ''}{result.stderr or ''}"
+    assert LAB_STORE_AS_FAILURE_MARKER in output, (
+        "Expected conditional echo after store_as stored step_failed from failed write_file"
+    )

--- a/tests/integration/containerlab/test_vars_all_levels.py
+++ b/tests/integration/containerlab/test_vars_all_levels.py
@@ -1,0 +1,50 @@
+"""Phase B/C: variable levels and Jinja2 filters via echo-only workflow."""
+
+import pytest
+
+from tests.integration.containerlab.conftest import run_nornflow_cli
+from tests.integration.containerlab.constants import (
+    LAB_VARS_ALL_LEVELS_WORKFLOW,
+    LAB_VARS_ENV_VALUE,
+    LAB_VARS_ENV_VAR,
+)
+from tests.integration.containerlab.lab_project import LabEnvironment
+from tests.integration.fixtures.constants import (
+    VARS_CLI_MARKER,
+    VARS_DOMAIN_MARKER,
+    VARS_GLOBAL_MARKER,
+    VARS_RUNTIME_MARKER,
+    VARS_WORKFLOW_MARKER,
+)
+
+
+def test_vars_all_levels_and_j2_filters(lab_environment: LabEnvironment, monkeypatch: pytest.MonkeyPatch) -> None:
+    """Echo workflow resolves env, global, domain, workflow, CLI, runtime vars and j2 filters."""
+    monkeypatch.setenv(f"NORNFLOW_VAR_{LAB_VARS_ENV_VAR}", LAB_VARS_ENV_VALUE)
+
+    result = run_nornflow_cli(
+        lab_environment,
+        [
+            "run",
+            LAB_VARS_ALL_LEVELS_WORKFLOW,
+            "--vars",
+            f"cli_marker={VARS_CLI_MARKER}",
+        ],
+        stream=False,
+    )
+    output = f"{result.stdout or ''}{result.stderr or ''}"
+    assert result.returncode == 0, output
+
+    for needle in (
+        f"env={LAB_VARS_ENV_VALUE}",
+        f"global={VARS_GLOBAL_MARKER}",
+        f"domain={VARS_DOMAIN_MARKER}",
+        f"workflow={VARS_WORKFLOW_MARKER}",
+        f"cli={VARS_CLI_MARKER}",
+        f"runtime={VARS_RUNTIME_MARKER}",
+        "override=RUNTIME_OK",
+        "j2_package=10-20",
+        "j2_builtin=True",
+        "j2_local=LAB:vars",
+    ):
+        assert needle in output, f"Expected {needle!r} in workflow output"

--- a/tests/integration/fixtures/common/workflows/store_as_failure_path.yaml
+++ b/tests/integration/fixtures/common/workflows/store_as_failure_path.yaml
@@ -1,0 +1,16 @@
+workflow:
+  name: Conditional rollback
+  failure_strategy: run-all
+  tasks:
+    - name: nornflow.write_file
+      args:
+        filename: ""
+        content: "x"
+      store_as:
+        step_failed: failed
+
+    - name: nornflow.echo
+      if: "{{ step_failed }}"
+      args:
+        msg: "NORNFLOW_STORE_AS_FAILURE_OK"
+      store_as: rollback_msg

--- a/tests/integration/fixtures/common/workflows/store_as_result_path.yaml
+++ b/tests/integration/fixtures/common/workflows/store_as_result_path.yaml
@@ -1,0 +1,12 @@
+workflow:
+  name: store_as result path equivalence
+  tasks:
+    - name: nornflow.echo
+      args:
+        msg: "LAB_STORE_AS_SIMPLE_OK"
+      store_as:
+        payload_b: result
+    - name: nornflow.echo
+      args:
+        msg: "{{ payload_b }}"
+      store_as: echo_back_b

--- a/tests/integration/fixtures/common/workflows/store_as_simple_mode.yaml
+++ b/tests/integration/fixtures/common/workflows/store_as_simple_mode.yaml
@@ -1,0 +1,11 @@
+workflow:
+  name: store_as simple mode equivalence
+  tasks:
+    - name: nornflow.echo
+      args:
+        msg: "LAB_STORE_AS_SIMPLE_OK"
+      store_as: payload_a
+    - name: nornflow.echo
+      args:
+        msg: "{{ payload_a }}"
+      store_as: echo_back_a

--- a/tests/integration/fixtures/constants.py
+++ b/tests/integration/fixtures/constants.py
@@ -1,0 +1,17 @@
+"""Shared markers and asset names for integration fixture workflows."""
+
+STORE_AS_ECHO_MESSAGE = "LAB_STORE_AS_SIMPLE_OK"
+STORE_AS_FAILURE_MARKER = "NORNFLOW_STORE_AS_FAILURE_OK"
+
+WORKFLOW_STORE_AS_SIMPLE = "store_as_simple_mode.yaml"
+WORKFLOW_STORE_AS_RESULT_PATH = "store_as_result_path.yaml"
+WORKFLOW_STORE_AS_FAILURE = "store_as_failure_path.yaml"
+
+VARS_ENV_MARKER = "ENV_OK"
+VARS_GLOBAL_MARKER = "GLOBAL_OK"
+VARS_DOMAIN_MARKER = "DOMAIN_OK"
+VARS_WORKFLOW_MARKER = "WORKFLOW_OK"
+VARS_CLI_MARKER = "CLI_OK"
+VARS_RUNTIME_MARKER = "RUNTIME_OK"
+
+WORKFLOW_VARS_ALL_LEVELS = "vars_all_levels.yaml"

--- a/tests/integration/project_bootstrap.py
+++ b/tests/integration/project_bootstrap.py
@@ -1,0 +1,100 @@
+"""Bootstrap a NornFlow project for integration tests via init + static fixtures."""
+
+import shutil
+import subprocess
+from collections.abc import Callable
+from pathlib import Path
+
+import yaml
+
+FIXTURES_COMMON = Path(__file__).resolve().parent / "fixtures" / "common"
+
+
+def merge_overlay(overlay_root: Path, project_root: Path) -> None:
+    """Copy all files from overlay_root onto project_root, preserving relative paths.
+
+    Args:
+        overlay_root: Directory tree to merge (e.g. fixtures/common).
+        project_root: Target NornFlow project root.
+    """
+    if not overlay_root.is_dir():
+        raise FileNotFoundError(f"Fixture overlay not found: {overlay_root}")
+
+    for src in overlay_root.rglob("*"):
+        if not src.is_file():
+            continue
+        rel = src.relative_to(overlay_root)
+        dest = project_root / rel
+        dest.parent.mkdir(parents=True, exist_ok=True)
+        shutil.copy2(src, dest)
+
+
+def patch_nornflow_settings(settings_file: Path, updates: dict[str, object]) -> None:
+    """Merge keys into an existing nornflow.yaml.
+
+    Args:
+        settings_file: Path to nornflow.yaml.
+        updates: Top-level keys to set or replace.
+    """
+    data = yaml.safe_load(settings_file.read_text()) or {}
+    data.update(updates)
+    settings_file.write_text(yaml.safe_dump(data, sort_keys=True))
+
+
+def run_nornflow_init(nornflow_executable: Path, project_root: Path) -> None:
+    """Run ``nornflow init`` non-interactively in project_root.
+
+    Args:
+        nornflow_executable: Path to nornflow CLI (venv or dev install).
+        project_root: Empty or new directory for the project.
+
+    Raises:
+        RuntimeError: When init exits non-zero.
+    """
+    project_root.mkdir(parents=True, exist_ok=True)
+    result = subprocess.run(
+        [str(nornflow_executable), "init"],
+        cwd=str(project_root),
+        input="y\n",
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+    if result.returncode != 0:
+        detail = result.stderr.strip() or result.stdout.strip() or "unknown error"
+        raise RuntimeError(f"nornflow init failed ({result.returncode}): {detail}")
+
+
+def bootstrap_nornflow_project(
+    project_root: Path,
+    *,
+    nornflow_executable: Path,
+    overlay_dirs: list[Path],
+    settings_patch: dict[str, object] | None = None,
+    write_hosts: Callable[[Path], None] | None = None,
+) -> Path:
+    """Skeleton a project with init, merge static fixtures, and optional patches.
+
+    Args:
+        project_root: Target project directory.
+        nornflow_executable: nornflow CLI used for init.
+        overlay_dirs: Overlay trees applied in order (later wins on collision).
+        settings_patch: Optional nornflow.yaml keys to merge after init.
+        write_hosts: Optional callback receiving hosts.yaml path for lab inventory.
+
+    Returns:
+        Path to nornflow.yaml.
+    """
+    run_nornflow_init(nornflow_executable, project_root)
+
+    for overlay in overlay_dirs:
+        merge_overlay(overlay, project_root)
+
+    settings_file = project_root / "nornflow.yaml"
+    if settings_patch:
+        patch_nornflow_settings(settings_file, settings_patch)
+
+    if write_hosts:
+        write_hosts(project_root / "nornir_configs" / "hosts.yaml")
+
+    return settings_file

--- a/tests/integration/project_bootstrap.py
+++ b/tests/integration/project_bootstrap.py
@@ -2,12 +2,39 @@
 
 import shutil
 import subprocess
+import sys
 from collections.abc import Callable
 from pathlib import Path
 
 import yaml
 
 FIXTURES_COMMON = Path(__file__).resolve().parent / "fixtures" / "common"
+
+
+def dev_nornflow_cli() -> Path:
+    """Return the nornflow CLI from PATH or the active virtualenv.
+
+    Returns:
+        Path to an existing ``nornflow`` executable.
+
+    Raises:
+        FileNotFoundError: When no nornflow executable is found.
+    """
+    candidates: list[Path] = []
+    on_path = shutil.which("nornflow")
+    if on_path:
+        candidates.append(Path(on_path))
+    candidates.append(Path(sys.executable).parent / "nornflow")
+
+    for candidate in candidates:
+        if candidate.is_file():
+            return candidate
+
+    searched = ", ".join(str(path) for path in candidates)
+    raise FileNotFoundError(
+        f"nornflow CLI not found (checked: {searched}). "
+        "Install the package in editable mode so the console script is available."
+    )
 
 
 def merge_overlay(overlay_root: Path, project_root: Path) -> None:
@@ -50,7 +77,11 @@ def run_nornflow_init(nornflow_executable: Path, project_root: Path) -> None:
 
     Raises:
         RuntimeError: When init exits non-zero.
+        FileNotFoundError: When nornflow_executable does not exist.
     """
+    if not nornflow_executable.is_file():
+        raise FileNotFoundError(f"nornflow executable not found: {nornflow_executable}")
+
     project_root.mkdir(parents=True, exist_ok=True)
     result = subprocess.run(
         [str(nornflow_executable), "init"],

--- a/tests/integration/store_as_lab.py
+++ b/tests/integration/store_as_lab.py
@@ -1,10 +1,9 @@
 """Minimal NornFlow project layout for store_as integration tests."""
 
-import shutil
-import sys
 from dataclasses import dataclass
 from pathlib import Path
 
+import pytest
 from nornflow.settings import NornFlowSettings
 
 from tests.integration.fixtures.constants import (
@@ -14,7 +13,11 @@ from tests.integration.fixtures.constants import (
     WORKFLOW_STORE_AS_RESULT_PATH,
     WORKFLOW_STORE_AS_SIMPLE,
 )
-from tests.integration.project_bootstrap import FIXTURES_COMMON, bootstrap_nornflow_project
+from tests.integration.project_bootstrap import (
+    FIXTURES_COMMON,
+    bootstrap_nornflow_project,
+    dev_nornflow_cli,
+)
 
 STORE_AS_HOST_NAME = "localhost"
 
@@ -38,14 +41,6 @@ class StoreAsIntegrationLab:
     host_name: str = STORE_AS_HOST_NAME
 
 
-def _dev_nornflow_cli() -> Path:
-    """Return nornflow CLI on PATH for the active Python environment."""
-    cli = shutil.which("nornflow")
-    if cli:
-        return Path(cli)
-    return Path(sys.executable).parent / "nornflow"
-
-
 def _write_single_host_inventory(hosts_path: Path, host_name: str) -> None:
     """Write a one-host SimpleInventory file for integration tests.
 
@@ -65,9 +60,14 @@ def build_store_as_integration_lab(lab_root: Path) -> StoreAsIntegrationLab:
     Returns:
         StoreAsIntegrationLab with settings ready for NornFlow initialization.
     """
+    try:
+        nornflow_cli = dev_nornflow_cli()
+    except FileNotFoundError as exc:
+        pytest.skip(str(exc))
+
     settings_file = bootstrap_nornflow_project(
         lab_root,
-        nornflow_executable=_dev_nornflow_cli(),
+        nornflow_executable=nornflow_cli,
         overlay_dirs=[FIXTURES_COMMON],
         write_hosts=lambda path: _write_single_host_inventory(path, STORE_AS_HOST_NAME),
     )

--- a/tests/integration/store_as_lab.py
+++ b/tests/integration/store_as_lab.py
@@ -1,15 +1,26 @@
 """Minimal NornFlow project layout for store_as integration tests."""
 
+import shutil
+import sys
 from dataclasses import dataclass
 from pathlib import Path
 
 from nornflow.settings import NornFlowSettings
 
-STORE_AS_ECHO_MESSAGE = "LAB_STORE_AS_SIMPLE_OK"
-STORE_AS_HOST_NAME = "router1"
+from tests.integration.fixtures.constants import (
+    STORE_AS_ECHO_MESSAGE,
+    STORE_AS_FAILURE_MARKER,
+    WORKFLOW_STORE_AS_FAILURE,
+    WORKFLOW_STORE_AS_RESULT_PATH,
+    WORKFLOW_STORE_AS_SIMPLE,
+)
+from tests.integration.project_bootstrap import FIXTURES_COMMON, bootstrap_nornflow_project
 
-WORKFLOW_SIMPLE_MODE = "store_as_simple_mode.yaml"
-WORKFLOW_RESULT_PATH = "store_as_result_path.yaml"
+STORE_AS_HOST_NAME = "localhost"
+
+WORKFLOW_SIMPLE_MODE = WORKFLOW_STORE_AS_SIMPLE
+WORKFLOW_RESULT_PATH = WORKFLOW_STORE_AS_RESULT_PATH
+WORKFLOW_FAILURE_PATH = WORKFLOW_STORE_AS_FAILURE
 
 
 @dataclass(frozen=True)
@@ -27,110 +38,52 @@ class StoreAsIntegrationLab:
     host_name: str = STORE_AS_HOST_NAME
 
 
-def _write_nornir_tree(lab_root: Path, host_name: str) -> Path:
-    """Write Nornir config and a one-host SimpleInventory.
+def _dev_nornflow_cli() -> Path:
+    """Return nornflow CLI on PATH for the active Python environment."""
+    cli = shutil.which("nornflow")
+    if cli:
+        return Path(cli)
+    return Path(sys.executable).parent / "nornflow"
+
+
+def _write_single_host_inventory(hosts_path: Path, host_name: str) -> None:
+    """Write a one-host SimpleInventory file for integration tests.
 
     Args:
-        lab_root: Lab root directory.
+        hosts_path: Destination hosts.yaml path.
         host_name: Inventory host name.
-
-    Returns:
-        Path to config.yaml.
     """
-    nornir_dir = lab_root / "nornir"
-    nornir_dir.mkdir(parents=True, exist_ok=True)
-
-    hosts_file = nornir_dir / "hosts.yaml"
-    groups_file = nornir_dir / "groups.yaml"
-    defaults_file = nornir_dir / "defaults.yaml"
-
-    hosts_file.write_text(f"{host_name}:\n  hostname: localhost\n  data: {{}}\n")
-    groups_file.write_text("{}\n")
-    defaults_file.write_text("{}\n")
-
-    config_file = nornir_dir / "config.yaml"
-    config_file.write_text(
-        f"""\
-inventory:
-  plugin: SimpleInventory
-  options:
-    host_file: '{hosts_file}'
-    group_file: '{groups_file}'
-    defaults_file: '{defaults_file}'
-runner:
-  plugin: threaded
-  options:
-    num_workers: 1
-"""
-    )
-    return config_file
-
-
-def _write_workflows(workflows_dir: Path, echo_message: str) -> None:
-    """Write simple-mode and result-path store_as workflows.
-
-    Args:
-        workflows_dir: Directory registered as local_workflows.
-        echo_message: Message passed to nornflow.echo (stored via store_as).
-    """
-    workflows_dir.mkdir(parents=True, exist_ok=True)
-
-    (workflows_dir / WORKFLOW_SIMPLE_MODE).write_text(
-        f"""\
-workflow:
-  name: store_as simple mode equivalence
-  tasks:
-    - name: nornflow.echo
-      args:
-        msg: "{echo_message}"
-      store_as: payload_a
-    - name: nornflow.echo
-      args:
-        msg: "{{{{ payload_a }}}}"
-      store_as: echo_back_a
-"""
-    )
-
-    (workflows_dir / WORKFLOW_RESULT_PATH).write_text(
-        f"""\
-workflow:
-  name: store_as result path equivalence
-  tasks:
-    - name: nornflow.echo
-      args:
-        msg: "{echo_message}"
-      store_as:
-        payload_b: result
-    - name: nornflow.echo
-      args:
-        msg: "{{{{ payload_b }}}}"
-      store_as: echo_back_b
-"""
-    )
+    hosts_path.write_text(f"{host_name}:\n  hostname: 127.0.0.1\n  data: {{}}\n")
 
 
 def build_store_as_integration_lab(lab_root: Path) -> StoreAsIntegrationLab:
     """Create a self-contained project for store_as integration tests.
 
     Args:
-        lab_root: Directory where nornir config, workflows, and vars dir are written.
+        lab_root: Directory where the temp project is created.
 
     Returns:
         StoreAsIntegrationLab with settings ready for NornFlow initialization.
     """
-    lab_root.mkdir(parents=True, exist_ok=True)
-
-    config_file = _write_nornir_tree(lab_root, STORE_AS_HOST_NAME)
-    workflows_dir = lab_root / "workflows"
-    _write_workflows(workflows_dir, STORE_AS_ECHO_MESSAGE)
-
-    vars_dir = lab_root / "vars"
-    vars_dir.mkdir(exist_ok=True)
-
-    settings = NornFlowSettings(
-        nornir_config_file=str(config_file),
-        local_workflows=[str(workflows_dir)],
-        vars_dir=str(vars_dir),
+    settings_file = bootstrap_nornflow_project(
+        lab_root,
+        nornflow_executable=_dev_nornflow_cli(),
+        overlay_dirs=[FIXTURES_COMMON],
+        write_hosts=lambda path: _write_single_host_inventory(path, STORE_AS_HOST_NAME),
     )
 
+    settings = NornFlowSettings.load(str(settings_file), base_dir=lab_root)
+
     return StoreAsIntegrationLab(root=lab_root, settings=settings)
+
+
+__all__ = [
+    "STORE_AS_ECHO_MESSAGE",
+    "STORE_AS_FAILURE_MARKER",
+    "STORE_AS_HOST_NAME",
+    "StoreAsIntegrationLab",
+    "WORKFLOW_FAILURE_PATH",
+    "WORKFLOW_RESULT_PATH",
+    "WORKFLOW_SIMPLE_MODE",
+    "build_store_as_integration_lab",
+]

--- a/tests/integration/store_as_lab.py
+++ b/tests/integration/store_as_lab.py
@@ -1,0 +1,136 @@
+"""Minimal NornFlow project layout for store_as integration tests."""
+
+from dataclasses import dataclass
+from pathlib import Path
+
+from nornflow.settings import NornFlowSettings
+
+STORE_AS_ECHO_MESSAGE = "LAB_STORE_AS_SIMPLE_OK"
+STORE_AS_HOST_NAME = "router1"
+
+WORKFLOW_SIMPLE_MODE = "store_as_simple_mode.yaml"
+WORKFLOW_RESULT_PATH = "store_as_result_path.yaml"
+
+
+@dataclass(frozen=True)
+class StoreAsIntegrationLab:
+    """Paths and settings for store_as workflow integration tests.
+
+    Attributes:
+        root: Root directory of the generated project layout.
+        settings: NornFlowSettings wired to local workflows and Nornir inventory.
+        host_name: Single inventory host used in workflows.
+    """
+
+    root: Path
+    settings: NornFlowSettings
+    host_name: str = STORE_AS_HOST_NAME
+
+
+def _write_nornir_tree(lab_root: Path, host_name: str) -> Path:
+    """Write Nornir config and a one-host SimpleInventory.
+
+    Args:
+        lab_root: Lab root directory.
+        host_name: Inventory host name.
+
+    Returns:
+        Path to config.yaml.
+    """
+    nornir_dir = lab_root / "nornir"
+    nornir_dir.mkdir(parents=True, exist_ok=True)
+
+    hosts_file = nornir_dir / "hosts.yaml"
+    groups_file = nornir_dir / "groups.yaml"
+    defaults_file = nornir_dir / "defaults.yaml"
+
+    hosts_file.write_text(f"{host_name}:\n  hostname: localhost\n  data: {{}}\n")
+    groups_file.write_text("{}\n")
+    defaults_file.write_text("{}\n")
+
+    config_file = nornir_dir / "config.yaml"
+    config_file.write_text(
+        f"""\
+inventory:
+  plugin: SimpleInventory
+  options:
+    host_file: '{hosts_file}'
+    group_file: '{groups_file}'
+    defaults_file: '{defaults_file}'
+runner:
+  plugin: threaded
+  options:
+    num_workers: 1
+"""
+    )
+    return config_file
+
+
+def _write_workflows(workflows_dir: Path, echo_message: str) -> None:
+    """Write simple-mode and result-path store_as workflows.
+
+    Args:
+        workflows_dir: Directory registered as local_workflows.
+        echo_message: Message passed to nornflow.echo (stored via store_as).
+    """
+    workflows_dir.mkdir(parents=True, exist_ok=True)
+
+    (workflows_dir / WORKFLOW_SIMPLE_MODE).write_text(
+        f"""\
+workflow:
+  name: store_as simple mode equivalence
+  tasks:
+    - name: nornflow.echo
+      args:
+        msg: "{echo_message}"
+      store_as: payload_a
+    - name: nornflow.echo
+      args:
+        msg: "{{{{ payload_a }}}}"
+      store_as: echo_back_a
+"""
+    )
+
+    (workflows_dir / WORKFLOW_RESULT_PATH).write_text(
+        f"""\
+workflow:
+  name: store_as result path equivalence
+  tasks:
+    - name: nornflow.echo
+      args:
+        msg: "{echo_message}"
+      store_as:
+        payload_b: result
+    - name: nornflow.echo
+      args:
+        msg: "{{{{ payload_b }}}}"
+      store_as: echo_back_b
+"""
+    )
+
+
+def build_store_as_integration_lab(lab_root: Path) -> StoreAsIntegrationLab:
+    """Create a self-contained project for store_as integration tests.
+
+    Args:
+        lab_root: Directory where nornir config, workflows, and vars dir are written.
+
+    Returns:
+        StoreAsIntegrationLab with settings ready for NornFlow initialization.
+    """
+    lab_root.mkdir(parents=True, exist_ok=True)
+
+    config_file = _write_nornir_tree(lab_root, STORE_AS_HOST_NAME)
+    workflows_dir = lab_root / "workflows"
+    _write_workflows(workflows_dir, STORE_AS_ECHO_MESSAGE)
+
+    vars_dir = lab_root / "vars"
+    vars_dir.mkdir(exist_ok=True)
+
+    settings = NornFlowSettings(
+        nornir_config_file=str(config_file),
+        local_workflows=[str(workflows_dir)],
+        vars_dir=str(vars_dir),
+    )
+
+    return StoreAsIntegrationLab(root=lab_root, settings=settings)

--- a/tests/integration/test_store_as_failure_path.py
+++ b/tests/integration/test_store_as_failure_path.py
@@ -1,0 +1,40 @@
+"""Integration test: store_as failure flag enables conditional follow-up task."""
+
+import nornflow.builtins.hooks  # noqa: F401
+import nornflow.builtins.tasks  # noqa: F401
+import pytest
+
+from nornflow.j2 import Jinja2Service
+from nornflow.nornflow import NornFlow
+
+from tests.integration.fixtures.constants import STORE_AS_FAILURE_MARKER
+from tests.integration.store_as_lab import (
+    STORE_AS_HOST_NAME,
+    WORKFLOW_FAILURE_PATH,
+    StoreAsIntegrationLab,
+    build_store_as_integration_lab,
+)
+
+
+@pytest.fixture(scope="module")
+def store_as_lab(tmp_path_factory: pytest.TempPathFactory) -> StoreAsIntegrationLab:
+    """Module-scoped project bootstrapped via nornflow init + static fixtures."""
+    lab_root = tmp_path_factory.mktemp("store_as_failure_integration")
+    return build_store_as_integration_lab(lab_root)
+
+
+def _reset_jinja2_singleton() -> None:
+    """Reset Jinja2Service singleton between NornFlow runs."""
+    Jinja2Service._instance = None
+    Jinja2Service._initialized = False
+
+
+def test_store_as_failure_path_enables_conditional_echo(store_as_lab: StoreAsIntegrationLab) -> None:
+    """write_file fails, store_as saves step_failed, if-hook echo runs and stores rollback_msg."""
+    _reset_jinja2_singleton()
+    nornflow = NornFlow(nornflow_settings=store_as_lab.settings, workflow=WORKFLOW_FAILURE_PATH)
+    nornflow.run()
+
+    vars_manager = nornflow.var_processor.vars_manager
+    assert vars_manager.get_nornflow_variable("step_failed", STORE_AS_HOST_NAME) is True
+    assert vars_manager.get_nornflow_variable("rollback_msg", STORE_AS_HOST_NAME) == STORE_AS_FAILURE_MARKER

--- a/tests/integration/test_store_as_simple_mode_equivalence.py
+++ b/tests/integration/test_store_as_simple_mode_equivalence.py
@@ -1,0 +1,77 @@
+"""Integration tests for store_as simple mode vs result-path equivalence."""
+
+import nornflow.builtins.hooks  # noqa: F401 — populate builtin hooks in HOOKS_CATALOG
+import nornflow.builtins.tasks  # noqa: F401 — populate builtin tasks in TASKS_CATALOG
+import pytest
+
+from nornflow.j2 import Jinja2Service
+from nornflow.nornflow import NornFlow
+
+from tests.integration.store_as_lab import (
+    STORE_AS_ECHO_MESSAGE,
+    STORE_AS_HOST_NAME,
+    WORKFLOW_RESULT_PATH,
+    WORKFLOW_SIMPLE_MODE,
+    StoreAsIntegrationLab,
+    build_store_as_integration_lab,
+)
+
+
+@pytest.fixture(scope="module")
+def store_as_lab(tmp_path_factory: pytest.TempPathFactory) -> StoreAsIntegrationLab:
+    """Session-scoped minimal NornFlow project with store_as workflows."""
+    lab_root = tmp_path_factory.mktemp("store_as_integration_lab")
+    return build_store_as_integration_lab(lab_root)
+
+
+def _reset_jinja2_singleton() -> None:
+    """Reset Jinja2Service singleton between NornFlow runs."""
+    Jinja2Service._instance = None
+    Jinja2Service._initialized = False
+
+
+def _run_workflow(lab: StoreAsIntegrationLab, workflow_file: str) -> NornFlow:
+    """Execute a workflow file and assert success.
+
+    Args:
+        lab: Generated integration lab.
+        workflow_file: Workflow filename in the lab workflows directory.
+
+    Returns:
+        NornFlow instance after run() completes.
+
+    Raises:
+        AssertionError: If run() returns a non-zero exit code.
+    """
+    _reset_jinja2_singleton()
+    nornflow = NornFlow(nornflow_settings=lab.settings, workflow=workflow_file)
+    exit_code = nornflow.run()
+    assert exit_code == 0, f"Workflow {workflow_file} failed with exit code {exit_code}"
+    return nornflow
+
+
+class TestStoreAsSimpleModeEquivalence:
+    """End-to-end store_as: simple mode vs extraction path result."""
+
+    def test_store_as_simple_and_result_path_same_variable(
+        self, store_as_lab: StoreAsIntegrationLab
+    ) -> None:
+        """store_as: var and store_as: {var: result} store identical runtime values."""
+        simple_run = _run_workflow(store_as_lab, WORKFLOW_SIMPLE_MODE)
+        result_path_run = _run_workflow(store_as_lab, WORKFLOW_RESULT_PATH)
+
+        vars_manager_simple = simple_run.var_processor.vars_manager
+        vars_manager_result = result_path_run.var_processor.vars_manager
+
+        payload_a = vars_manager_simple.get_nornflow_variable("payload_a", STORE_AS_HOST_NAME)
+        payload_b = vars_manager_result.get_nornflow_variable("payload_b", STORE_AS_HOST_NAME)
+
+        assert payload_a == STORE_AS_ECHO_MESSAGE
+        assert payload_b == STORE_AS_ECHO_MESSAGE
+        assert payload_a == payload_b
+
+        echo_back_a = vars_manager_simple.get_nornflow_variable("echo_back_a", STORE_AS_HOST_NAME)
+        echo_back_b = vars_manager_result.get_nornflow_variable("echo_back_b", STORE_AS_HOST_NAME)
+
+        assert echo_back_a == STORE_AS_ECHO_MESSAGE
+        assert echo_back_b == STORE_AS_ECHO_MESSAGE

--- a/tests/unit/builtins/test_single_hook.py
+++ b/tests/unit/builtins/test_single_hook.py
@@ -284,7 +284,7 @@ class TestSingleHook:
     def test_execute_hook_validations_hooks_without_if(self, mock_task):
         """Test validation passes when hooks dict has other hooks but not 'if'."""
         hook = SingleHook(True)
-        mock_task.hooks = {"shush": True, "set_to": "my_var"}
+        mock_task.hooks = {"shush": True, "store_as": "my_var"}
 
         hook.execute_hook_validations(mock_task)
 

--- a/tests/unit/builtins/test_store_as_conditional_rollback.py
+++ b/tests/unit/builtins/test_store_as_conditional_rollback.py
@@ -1,0 +1,61 @@
+"""Unit test: conditional rollback workflow via store_as failed flag + if hook."""
+
+import shutil
+import sys
+from pathlib import Path
+
+import nornflow.builtins.hooks  # noqa: F401
+import nornflow.builtins.tasks  # noqa: F401
+import pytest
+
+from nornflow.j2 import Jinja2Service
+from nornflow.nornflow import NornFlow
+from nornflow.settings import NornFlowSettings
+
+from tests.integration.fixtures.constants import STORE_AS_FAILURE_MARKER, WORKFLOW_STORE_AS_FAILURE
+from tests.integration.project_bootstrap import FIXTURES_COMMON, bootstrap_nornflow_project
+
+HOST_NAME = "localhost"
+
+
+def _dev_nornflow_cli() -> Path:
+    cli = shutil.which("nornflow")
+    if cli:
+        return Path(cli)
+    return Path(sys.executable).parent / "nornflow"
+
+
+def _write_single_host(hosts_path: Path) -> None:
+    hosts_path.write_text(f"{HOST_NAME}:\n  hostname: 127.0.0.1\n  data: {{}}\n")
+
+
+@pytest.fixture(scope="module")
+def rollback_lab(tmp_path_factory: pytest.TempPathFactory) -> NornFlowSettings:
+    """Bootstrapped project with static store_as failure-path workflow."""
+    lab_root = tmp_path_factory.mktemp("store_as_rollback_unit")
+    settings_file = bootstrap_nornflow_project(
+        lab_root,
+        nornflow_executable=_dev_nornflow_cli(),
+        overlay_dirs=[FIXTURES_COMMON],
+        write_hosts=_write_single_host,
+    )
+    return NornFlowSettings.load(str(settings_file), base_dir=lab_root)
+
+
+def _reset_jinja2_singleton() -> None:
+    Jinja2Service._instance = None
+    Jinja2Service._initialized = False
+
+
+class TestStoreAsConditionalRollbackWorkflow:
+    """End-to-end workflow: failed write_file -> step_failed -> conditional echo."""
+
+    def test_failure_path_stores_flag_and_runs_rollback_echo(self, rollback_lab: NornFlowSettings) -> None:
+        """Matches the documented conditional rollback YAML pattern."""
+        _reset_jinja2_singleton()
+        nornflow = NornFlow(nornflow_settings=rollback_lab, workflow=WORKFLOW_STORE_AS_FAILURE)
+        nornflow.run()
+
+        vars_manager = nornflow.var_processor.vars_manager
+        assert vars_manager.get_nornflow_variable("step_failed", HOST_NAME) is True
+        assert vars_manager.get_nornflow_variable("rollback_msg", HOST_NAME) == STORE_AS_FAILURE_MARKER

--- a/tests/unit/builtins/test_store_as_conditional_rollback.py
+++ b/tests/unit/builtins/test_store_as_conditional_rollback.py
@@ -1,7 +1,5 @@
 """Unit test: conditional rollback workflow via store_as failed flag + if hook."""
 
-import shutil
-import sys
 from pathlib import Path
 
 import nornflow.builtins.hooks  # noqa: F401
@@ -13,16 +11,9 @@ from nornflow.nornflow import NornFlow
 from nornflow.settings import NornFlowSettings
 
 from tests.integration.fixtures.constants import STORE_AS_FAILURE_MARKER, WORKFLOW_STORE_AS_FAILURE
-from tests.integration.project_bootstrap import FIXTURES_COMMON, bootstrap_nornflow_project
+from tests.integration.project_bootstrap import FIXTURES_COMMON, bootstrap_nornflow_project, dev_nornflow_cli
 
 HOST_NAME = "localhost"
-
-
-def _dev_nornflow_cli() -> Path:
-    cli = shutil.which("nornflow")
-    if cli:
-        return Path(cli)
-    return Path(sys.executable).parent / "nornflow"
 
 
 def _write_single_host(hosts_path: Path) -> None:
@@ -32,10 +23,15 @@ def _write_single_host(hosts_path: Path) -> None:
 @pytest.fixture(scope="module")
 def rollback_lab(tmp_path_factory: pytest.TempPathFactory) -> NornFlowSettings:
     """Bootstrapped project with static store_as failure-path workflow."""
+    try:
+        nornflow_cli = dev_nornflow_cli()
+    except FileNotFoundError as exc:
+        pytest.skip(str(exc))
+
     lab_root = tmp_path_factory.mktemp("store_as_rollback_unit")
     settings_file = bootstrap_nornflow_project(
         lab_root,
-        nornflow_executable=_dev_nornflow_cli(),
+        nornflow_executable=nornflow_cli,
         overlay_dirs=[FIXTURES_COMMON],
         write_hosts=_write_single_host,
     )

--- a/tests/unit/builtins/test_store_as_hook.py
+++ b/tests/unit/builtins/test_store_as_hook.py
@@ -1,4 +1,4 @@
-from unittest.mock import MagicMock
+from unittest.mock import MagicMock, call
 
 import pytest
 from nornir.core.inventory import Host
@@ -6,6 +6,36 @@ from nornir.core.task import MultiResult, Result, Task
 
 from nornflow.builtins.hooks import StoreAsHook
 from nornflow.hooks.exceptions import HookError, HookValidationError
+
+
+def _make_host(name: str = "router1") -> Host:
+    """Create a minimal Nornir Host for store_as tests."""
+    return Host(name=name, hostname=name, data={})
+
+
+def _multiresult_for(host: Host, host_result: Result, task_name: str = "test_task") -> MultiResult:
+    """Build a per-host MultiResult containing a single host Result."""
+    multi = MultiResult(task_name)
+    multi.append(host_result)
+    return multi
+
+
+def _run_store_as(
+    hook_value,
+    host: Host,
+    host_result: Result,
+    vars_manager: MagicMock | None = None,
+) -> tuple[StoreAsHook, MagicMock]:
+    """Run task_instance_completed with vars_manager wired into hook context."""
+    hook = StoreAsHook(hook_value)
+    manager = vars_manager or MagicMock()
+    hook._current_context = {"vars_manager": manager}
+    hook.task_instance_completed(
+        MagicMock(spec=Task),
+        host,
+        _multiresult_for(host, host_result),
+    )
+    return hook, manager
 
 
 class TestStoreAsHook:
@@ -248,3 +278,223 @@ class TestStoreAsHook:
         assert "set" in error_message
         assert "echo" in error_message
         assert "store_as" in error_message
+
+    def test_failed_task_stores_failed_flag_true(self):
+        """Failed task stores Result.failed via wrapper path."""
+        host = _make_host()
+        host_result = Result(host=host, result=None, failed=True)
+        _, manager = _run_store_as({"flag": "failed"}, host, host_result)
+
+        manager.set_runtime_variable.assert_called_once_with("flag", True, host.name)
+
+    def test_successful_task_stores_failed_flag_false(self):
+        """Successful task stores Result.failed as false."""
+        host = _make_host()
+        host_result = Result(host=host, result={"ok": True}, failed=False)
+        _, manager = _run_store_as({"flag": "failed"}, host, host_result)
+
+        manager.set_runtime_variable.assert_called_once_with("flag", False, host.name)
+
+    def test_multi_host_failure_is_per_host(self):
+        """Each host gets its own stored failed flag from its Result."""
+        host_failed = _make_host("failed-host")
+        host_ok = _make_host("ok-host")
+        manager_failed = MagicMock()
+        manager_ok = MagicMock()
+
+        _run_store_as(
+            {"flag": "failed"},
+            host_failed,
+            Result(host=host_failed, result=None, failed=True),
+            manager_failed,
+        )
+        _run_store_as(
+            {"flag": "failed"},
+            host_ok,
+            Result(host=host_ok, result={"ok": True}, failed=False),
+            manager_ok,
+        )
+
+        manager_failed.set_runtime_variable.assert_called_once_with("flag", True, "failed-host")
+        manager_ok.set_runtime_variable.assert_called_once_with("flag", False, "ok-host")
+
+    def test_failed_task_stores_changed_and_result_paths(self):
+        """Failed task still stores wrapper paths changed and result."""
+        host = _make_host()
+        payload = {"partial": True}
+        host_result = Result(host=host, result=payload, failed=True, changed=True)
+        _, manager = _run_store_as({"was_changed": "changed", "payload": "result"}, host, host_result)
+
+        assert manager.set_runtime_variable.call_args_list == [
+            call("was_changed", True, host.name),
+            call("payload", payload, host.name),
+        ]
+
+    def test_failed_task_stores_simple_mode_on_failure(self):
+        """Simple mode stores Result.result even when the task failed."""
+        host = _make_host()
+        payload = {"partial": True}
+        host_result = Result(host=host, result=payload, failed=True)
+        _, manager = _run_store_as("capture_var", host, host_result)
+
+        manager.set_runtime_variable.assert_called_once_with("capture_var", payload, host.name)
+
+    def test_failed_task_stores_simple_mode_none_result(self):
+        """Simple mode stores None when failed task has Result.result is None."""
+        host = _make_host()
+        host_result = Result(host=host, result=None, failed=True)
+        _, manager = _run_store_as("capture_var", host, host_result)
+
+        manager.set_runtime_variable.assert_called_once_with("capture_var", None, host.name)
+
+    @pytest.mark.parametrize(
+        "task_result",
+        [
+            "show run output...",
+            {"output": "timeout", "vendor": "cisco"},
+            None,
+        ],
+    )
+    def test_simple_mode_equivalent_to_result_path(self, task_result):
+        """Simple mode stores the same value as extraction path result."""
+        host = _make_host()
+        host_result = Result(host=host, result=task_result, failed=task_result is None)
+
+        manager_simple = MagicMock()
+        _run_store_as("running_config", host, host_result, manager_simple)
+
+        manager_path = MagicMock()
+        _run_store_as({"running_config": "result"}, host, host_result, manager_path)
+
+        assert manager_simple.set_runtime_variable.call_args == manager_path.set_runtime_variable.call_args
+
+    def test_failed_task_payload_shorthand_stores_when_present(self):
+        """Payload shorthand works on failed tasks when the key exists."""
+        host = _make_host()
+        host_result = Result(host=host, result={"output": "timeout"}, failed=True)
+        _, manager = _run_store_as({"detail": "output"}, host, host_result)
+
+        manager.set_runtime_variable.assert_called_once_with("detail", "timeout", host.name)
+
+    def test_extraction_missing_key_raises(self):
+        """Missing extraction key raises HookValidationError from task_instance_completed."""
+        host = _make_host()
+        host_result = Result(host=host, result={"vendor": "cisco"}, failed=False)
+        hook = StoreAsHook({"bad": "missing_key"})
+        manager = MagicMock()
+        hook._current_context = {"vars_manager": manager}
+
+        with pytest.raises(HookValidationError):
+            hook.task_instance_completed(
+                MagicMock(spec=Task),
+                host,
+                _multiresult_for(host, host_result),
+            )
+
+        manager.set_runtime_variable.assert_not_called()
+
+    def test_extract_wrapper_attribute_name(self):
+        """Path name reads Result.name when set on the Result object."""
+        host = _make_host()
+        host_result = Result(host=host, result={"ignored": True}, name="deploy")
+        _, manager = _run_store_as({"task_name": "name"}, host, host_result)
+
+        manager.set_runtime_variable.assert_called_once_with("task_name", "deploy", host.name)
+
+    def test_extract_wrapper_attribute_severity_level(self):
+        """Path severity_level reads Result.severity_level."""
+        host = _make_host()
+        host_result = Result(host=host, result={}, severity_level=20)
+        _, manager = _run_store_as({"level": "severity_level"}, host, host_result)
+
+        manager.set_runtime_variable.assert_called_once_with("level", 20, host.name)
+
+    def test_extract_invalid_path_raises(self):
+        """Unknown shorthand path raises HookValidationError."""
+        host = _make_host()
+        host_result = Result(host=host, result={}, failed=False)
+        hook = StoreAsHook({"x": "this_key_definitely_does_not_exist"})
+        manager = MagicMock()
+        hook._current_context = {"vars_manager": manager}
+
+        with pytest.raises(HookValidationError):
+            hook.task_instance_completed(
+                MagicMock(spec=Task),
+                host,
+                _multiresult_for(host, host_result),
+            )
+
+    def test_payload_shorthand_equals_result_dot_key(self):
+        """Shorthand vendor and explicit result.vendor store the same value."""
+        host = _make_host()
+        host_result = Result(host=host, result={"vendor": "arista"})
+        manager_shorthand = MagicMock()
+        _run_store_as({"vendor_a": "vendor"}, host, host_result, manager_shorthand)
+
+        manager_explicit = MagicMock()
+        _run_store_as({"vendor_b": "result.vendor"}, host, host_result, manager_explicit)
+
+        assert manager_shorthand.set_runtime_variable.call_args == call("vendor_a", "arista", host.name)
+        assert manager_explicit.set_runtime_variable.call_args == call("vendor_b", "arista", host.name)
+
+    def test_wrapper_wins_on_collision(self):
+        """Bare vendor follows Result attribute; result.vendor follows payload key."""
+        host = _make_host()
+        host_result = Result(
+            host=host,
+            result={"vendor": "payload"},
+            vendor="wrapper",
+        )
+        manager_bare = MagicMock()
+        _run_store_as({"from_wrapper": "vendor"}, host, host_result, manager_bare)
+
+        manager_explicit = MagicMock()
+        _run_store_as({"from_payload": "result.vendor"}, host, host_result, manager_explicit)
+
+        manager_bare.set_runtime_variable.assert_called_once_with("from_wrapper", "wrapper", host.name)
+        manager_explicit.set_runtime_variable.assert_called_once_with("from_payload", "payload", host.name)
+
+    def test_wrapper_paths_processed_before_payload_raises(self):
+        """Wrapper path stores before shorthand path hard-fails (YAML order irrelevant)."""
+        host = _make_host()
+        host_result = Result(host=host, result=None, failed=True)
+        hook = StoreAsHook({"bad": "missing_payload_key", "flag": "failed"})
+        manager = MagicMock()
+        hook._current_context = {"vars_manager": manager}
+
+        with pytest.raises(HookValidationError):
+            hook.task_instance_completed(
+                MagicMock(spec=Task),
+                host,
+                _multiresult_for(host, host_result),
+            )
+
+        manager.set_runtime_variable.assert_called_once_with("flag", True, host.name)
+
+    def test_failed_mixed_dict_stores_failed_before_payload_raises(self):
+        """Alias: failed flag stored before bad payload path aborts."""
+        self.test_wrapper_paths_processed_before_payload_raises()
+
+    def test_failed_multiresult_does_not_block_successful_host(self):
+        """Aggregate MultiResult.failed does not skip store_as for a successful host."""
+        host_ok = _make_host("ok-host")
+        host_failed = _make_host("failed-host")
+        multi = MultiResult("test_task")
+        multi.append(Result(host=host_ok, result="ok", failed=False))
+        multi.append(Result(host=host_failed, result="err", failed=True))
+        assert multi.failed is True
+
+        hook = StoreAsHook("capture_var")
+        manager = MagicMock()
+        hook._current_context = {"vars_manager": manager}
+        hook.task_instance_completed(MagicMock(spec=Task), host_ok, multi)
+
+        manager.set_runtime_variable.assert_called_once_with("capture_var", "ok", "ok-host")
+
+    def test_skipped_host_does_not_store_on_failure(self):
+        """Skipped hosts do not store variables even when other paths would apply."""
+        host = _make_host()
+        host_result = Result(host=host, result={"output": "x"}, failed=True, skipped=True)
+        _, manager = _run_store_as({"flag": "failed"}, host, host_result)
+
+        manager.set_runtime_variable.assert_not_called()

--- a/tests/unit/builtins/test_store_as_hook.py
+++ b/tests/unit/builtins/test_store_as_hook.py
@@ -5,7 +5,7 @@ from nornir.core.inventory import Host
 from nornir.core.task import MultiResult, Result, Task
 
 from nornflow.builtins.hooks import StoreAsHook
-from nornflow.hooks.exceptions import HookValidationError
+from nornflow.hooks.exceptions import HookError, HookValidationError
 
 
 class TestStoreAsHook:
@@ -118,35 +118,48 @@ class TestStoreAsHook:
 
         mock_vars_manager.set_runtime_variable.assert_not_called()
 
-    def test_task_instance_completed_no_vars_manager_does_nothing(self):
-        """Test that task_instance_completed does nothing when vars_manager is not in context."""
+    def test_task_instance_completed_no_vars_manager_raises(self):
+        """Test that missing vars_manager raises HookError."""
         hook = StoreAsHook("test_variable")
-        
+
         mock_task = MagicMock(spec=Task)
         mock_host = MagicMock(spec=Host)
         mock_host.name = "router1"
         mock_result = MagicMock(spec=MultiResult)
-        
-        # No vars_manager in context
+
         hook._current_context = {}
 
-        # Should not raise any exceptions
-        hook.task_instance_completed(mock_task, mock_host, mock_result)
+        with pytest.raises(HookError, match="Variables manager not available"):
+            hook.task_instance_completed(mock_task, mock_host, mock_result)
 
-    def test_task_instance_completed_no_context_does_nothing(self):
-        """Test that task_instance_completed handles missing context gracefully."""
+    def test_task_instance_completed_no_host_result_raises(self):
+        """Test that empty per-host MultiResult raises HookError."""
         hook = StoreAsHook("test_variable")
-        
+
+        mock_task = MagicMock(spec=Task)
+        mock_host = MagicMock(spec=Host)
+        mock_host.name = "router1"
+        mock_result = MultiResult("test_task")
+
+        mock_vars_manager = MagicMock()
+        hook._current_context = {"vars_manager": mock_vars_manager}
+
+        with pytest.raises(HookError, match="No Result for host 'router1'"):
+            hook.task_instance_completed(mock_task, mock_host, mock_result)
+
+    def test_task_instance_completed_no_context_raises(self):
+        """Test that missing hook context raises HookError."""
+        hook = StoreAsHook("test_variable")
+
         mock_task = MagicMock(spec=Task)
         mock_host = MagicMock(spec=Host)
         mock_host.name = "router1"
         mock_result = MagicMock(spec=MultiResult)
-        
-        # No context set
+
         hook._current_context = None
 
-        # Should not raise any exceptions
-        hook.task_instance_completed(mock_task, mock_host, mock_result)
+        with pytest.raises(HookError, match="Variables manager not available"):
+            hook.task_instance_completed(mock_task, mock_host, mock_result)
 
     def test_context_property_returns_empty_when_no_context(self):
         """Test context property returns empty dict when no context is set."""

--- a/tests/unit/builtins/test_store_as_hook.py
+++ b/tests/unit/builtins/test_store_as_hook.py
@@ -4,34 +4,34 @@ import pytest
 from nornir.core.inventory import Host
 from nornir.core.task import MultiResult, Result, Task
 
-from nornflow.builtins.hooks import SetToHook
+from nornflow.builtins.hooks import StoreAsHook
 from nornflow.hooks.exceptions import HookValidationError
 
 
-class TestSetToHook:
-    """Test suite for SetToHook."""
+class TestStoreAsHook:
+    """Test suite for StoreAsHook."""
 
     def test_hook_name_registration(self):
         """Test that hook has correct name for registration."""
-        assert SetToHook.hook_name == "set_to"
+        assert StoreAsHook.hook_name == "store_as"
 
     def test_run_once_per_task_flag(self):
         """Test that hook runs per host, not once per task."""
-        assert SetToHook.run_once_per_task is False
+        assert StoreAsHook.run_once_per_task is False
 
     def test_init_with_value(self):
         """Test hook initialization with a variable name."""
-        hook = SetToHook("my_variable")
+        hook = StoreAsHook("my_variable")
         assert hook.value == "my_variable"
 
     def test_init_without_value(self):
         """Test hook initialization without a value."""
-        hook = SetToHook()
+        hook = StoreAsHook()
         assert hook.value is None
 
     def test_execute_hook_validations_valid_task(self):
         """Test validation passes for compatible tasks."""
-        hook = SetToHook("var_name")
+        hook = StoreAsHook("var_name")
         mock_task_model = MagicMock()
         mock_task_model.name = "ping"
 
@@ -40,34 +40,34 @@ class TestSetToHook:
 
     def test_execute_hook_validations_invalid_set_task(self):
         """Test validation fails for 'set' task."""
-        hook = SetToHook("var_name")
+        hook = StoreAsHook("var_name")
         mock_task_model = MagicMock()
         mock_task_model.name = "set"
 
-        with pytest.raises(HookValidationError, match="Hook 'SetToHook' cannot be used with task 'set'"):
+        with pytest.raises(HookValidationError, match="Hook 'StoreAsHook' cannot be used with task 'set'"):
             hook.execute_hook_validations(mock_task_model)
 
     def test_execute_hook_validations_invalid_echo_task(self):
         """Test validation fails for 'echo' task."""
-        hook = SetToHook("var_name")
+        hook = StoreAsHook("var_name")
         mock_task_model = MagicMock()
         mock_task_model.name = "echo"
 
-        with pytest.raises(HookValidationError, match="Hook 'SetToHook' cannot be used with task 'echo'"):
+        with pytest.raises(HookValidationError, match="Hook 'StoreAsHook' cannot be used with task 'echo'"):
             hook.execute_hook_validations(mock_task_model)
 
-    def test_execute_hook_validations_invalid_set_to_task(self):
-        """Test validation fails for 'set_to' task."""
-        hook = SetToHook("var_name")
+    def test_execute_hook_validations_invalid_store_as_task(self):
+        """Test validation fails for 'store_as' task."""
+        hook = StoreAsHook("var_name")
         mock_task_model = MagicMock()
-        mock_task_model.name = "set_to"
+        mock_task_model.name = "store_as"
 
-        with pytest.raises(HookValidationError, match="Hook 'SetToHook' cannot be used with task 'set_to'"):
+        with pytest.raises(HookValidationError, match="Hook 'StoreAsHook' cannot be used with task 'store_as'"):
             hook.execute_hook_validations(mock_task_model)
 
     def test_task_instance_completed_stores_result(self):
         """Test that task_instance_completed stores result in runtime variable."""
-        hook = SetToHook("test_variable")
+        hook = StoreAsHook("test_variable")
         
         mock_task = MagicMock(spec=Task)
         mock_host = MagicMock(spec=Host)
@@ -89,7 +89,7 @@ class TestSetToHook:
 
     def test_task_instance_completed_no_value_does_nothing(self):
         """Test that task_instance_completed does nothing when value is None."""
-        hook = SetToHook(None)
+        hook = StoreAsHook(None)
         
         mock_task = MagicMock(spec=Task)
         mock_host = MagicMock(spec=Host)
@@ -105,7 +105,7 @@ class TestSetToHook:
 
     def test_task_instance_completed_no_result_does_nothing(self):
         """Test that task_instance_completed does nothing when result is None."""
-        hook = SetToHook("test_variable")
+        hook = StoreAsHook("test_variable")
         
         mock_task = MagicMock(spec=Task)
         mock_host = MagicMock(spec=Host)
@@ -120,7 +120,7 @@ class TestSetToHook:
 
     def test_task_instance_completed_no_vars_manager_does_nothing(self):
         """Test that task_instance_completed does nothing when vars_manager is not in context."""
-        hook = SetToHook("test_variable")
+        hook = StoreAsHook("test_variable")
         
         mock_task = MagicMock(spec=Task)
         mock_host = MagicMock(spec=Host)
@@ -135,7 +135,7 @@ class TestSetToHook:
 
     def test_task_instance_completed_no_context_does_nothing(self):
         """Test that task_instance_completed handles missing context gracefully."""
-        hook = SetToHook("test_variable")
+        hook = StoreAsHook("test_variable")
         
         mock_task = MagicMock(spec=Task)
         mock_host = MagicMock(spec=Host)
@@ -150,14 +150,14 @@ class TestSetToHook:
 
     def test_context_property_returns_empty_when_no_context(self):
         """Test context property returns empty dict when no context is set."""
-        hook = SetToHook("test_variable")
+        hook = StoreAsHook("test_variable")
         
         context = hook.context
         assert context == {}
 
     def test_task_instance_completed_with_complex_result(self):
         """Test storing complex result objects."""
-        hook = SetToHook("complex_var")
+        hook = StoreAsHook("complex_var")
         
         mock_task = MagicMock(spec=Task)
         mock_host = MagicMock(spec=Host)
@@ -177,7 +177,7 @@ class TestSetToHook:
 
     def test_other_processor_methods_do_nothing(self):
         """Test that other processor methods have no implementation."""
-        hook = SetToHook("test_var")
+        hook = StoreAsHook("test_var")
         mock_task = MagicMock()
         mock_host = MagicMock()
         mock_result = MagicMock()
@@ -191,7 +191,7 @@ class TestSetToHook:
 
     def test_should_execute_always_returns_true(self):
         """Test that hook executes for every host (run_once_per_task=False)."""
-        hook = SetToHook("test_var")
+        hook = StoreAsHook("test_var")
         mock_task = MagicMock()
 
         # Should always return True since run_once_per_task is False
@@ -201,7 +201,7 @@ class TestSetToHook:
 
     def test_task_instance_completed_handles_string_host_name(self):
         """Test that hook works correctly with string host names."""
-        hook = SetToHook("host_result")
+        hook = StoreAsHook("host_result")
         
         mock_task = MagicMock(spec=Task)
         mock_host = MagicMock(spec=Host)
@@ -224,7 +224,7 @@ class TestSetToHook:
 
     def test_execute_hook_validations_error_message_includes_incompatible_tasks(self):
         """Test that validation error message lists all incompatible tasks."""
-        hook = SetToHook("var_name")
+        hook = StoreAsHook("var_name")
         mock_task_model = MagicMock()
         mock_task_model.name = "set"
 
@@ -234,4 +234,4 @@ class TestSetToHook:
         error_message = str(exc_info.value)
         assert "set" in error_message
         assert "echo" in error_message
-        assert "set_to" in error_message
+        assert "store_as" in error_message

--- a/tests/unit/hooks/test_base.py
+++ b/tests/unit/hooks/test_base.py
@@ -139,20 +139,20 @@ class TestHook:
 
     def test_reusing_builtin_name_registers_qualified_local_copy(self):
         """Test that reusing a builtin hook name creates a separate local qualified entry."""
-        from nornflow.builtins.hooks import SetToHook
+        from nornflow.builtins.hooks import StoreAsHook
 
-        class FakeSetToHook(Hook):
-            hook_name = "set_to"
+        class FakeStoreAsHook(Hook):
+            hook_name = "store_as"
 
-        assert HOOKS_CATALOG.resolve("set_to") is SetToHook
-        assert HOOKS_CATALOG.resolve("local.set_to") is FakeSetToHook
+        assert HOOKS_CATALOG.resolve("store_as") is StoreAsHook
+        assert HOOKS_CATALOG.resolve("local.store_as") is FakeStoreAsHook
 
     def test_builtin_hooks_registered(self):
         """Test that built-in hooks are properly registered."""
-        from nornflow.builtins.hooks import IfHook, SetToHook, ShushHook
+        from nornflow.builtins.hooks import IfHook, ShushHook, StoreAsHook
 
         assert HOOKS_CATALOG.resolve("if") is IfHook
-        assert HOOKS_CATALOG.resolve("set_to") is SetToHook
+        assert HOOKS_CATALOG.resolve("store_as") is StoreAsHook
         assert HOOKS_CATALOG.resolve("shush") is ShushHook
 
     def test_user_hook_is_builtin_defaults_false(self):
@@ -164,5 +164,5 @@ class TestHook:
 
     def test_builtin_hooks_have_is_builtin_in_sources(self):
         """Test that builtin hooks are marked is_builtin=True in HOOKS_CATALOG.sources."""
-        for hook_name in ("if", "set_to", "shush", "single"):
+        for hook_name in ("if", "store_as", "shush", "single"):
             assert HOOKS_CATALOG.sources[f"nornflow.{hook_name}"]["is_builtin"] is True

--- a/tests/unit/hooks/test_loader.py
+++ b/tests/unit/hooks/test_loader.py
@@ -1,24 +1,24 @@
 from unittest.mock import MagicMock, patch
 
-from nornflow.builtins.hooks import SetToHook
+from nornflow.builtins.hooks import StoreAsHook
 from nornflow.hooks.loader import load_hooks
 
 
 class TestHookLoader:
     """Test suite for hook loading operations."""
 
-    @patch("nornflow.hooks.loader.HOOKS_CATALOG", {"set_to": SetToHook})
+    @patch("nornflow.hooks.loader.HOOKS_CATALOG", {"store_as": StoreAsHook})
     def test_load_hooks_with_hooks(self):
         """Test loading hooks from a hooks dictionary."""
         # Create hooks configuration dict
         hooks_dict = {
-            "set_to": "test_variable"
+            "store_as": "test_variable"
         }
-        
+
         hooks = load_hooks(hooks_dict)
-        
+
         assert len(hooks) == 1
-        assert isinstance(hooks[0], SetToHook)
+        assert isinstance(hooks[0], StoreAsHook)
         assert hooks[0].value == "test_variable"
 
     def test_load_hooks_empty_dict(self):

--- a/tests/unit/models/test_task_model.py
+++ b/tests/unit/models/test_task_model.py
@@ -77,21 +77,21 @@ class TestTaskModel:
         assert isinstance(task.args, dict)
         assert task.args["key"] == ("list", "values")  # Converted to tuple
 
-    def test_validate_set_to(self):
-        """Test set_to validation creates SetToHook."""
-        from nornflow.builtins.hooks import SetToHook
-        
+    def test_validate_store_as(self):
+        """Test store_as validation creates StoreAsHook."""
+        from nornflow.builtins.hooks import StoreAsHook
+
         # In the refactored hook framework, hooks are configured through a hooks dictionary
         # where keys are hook names and values are the hook parameter values
-        task = TaskModel(name="test_task", hooks=HashableDict({"set_to": "var_name"}))
-        
+        task = TaskModel(name="test_task", hooks=HashableDict({"store_as": "var_name"}))
+
         # The task's get_hooks method should return the hook instances
         hooks = task.get_hooks()
-        
-        # Check that a SetToHook was created and is in the hooks
-        set_to_hooks = [hook for hook in hooks if isinstance(hook, SetToHook)]
-        assert len(set_to_hooks) == 1
-        assert set_to_hooks[0].value == "var_name"
+
+        # Check that a StoreAsHook was created and is in the hooks
+        store_as_hooks = [hook for hook in hooks if isinstance(hook, StoreAsHook)]
+        assert len(store_as_hooks) == 1
+        assert store_as_hooks[0].value == "var_name"
 
     def test_create_auto_increment_id(self):
         """Test create method auto-increments id."""


### PR DESCRIPTION
## Summary

Renames the built-in **`set_to`** hook to **`store_as`** and fixes [#87](https://github.com/theandrelima/nornflow/issues/87): failed tasks can still populate runtime variables when extraction paths are valid.

- **`store_as` runs on success and failure** — removed the early return that skipped storage when `Result.failed` was true; skipped hosts still store nothing.
- **Simple mode stores `Result.result` only** — not the full Nornir `Result` object; equivalent to `store_as: { var: result }`.
- **Hybrid extraction paths** — first segment on `Result` (`failed`, `changed`, `result`) vs shorthand into `Result.result`; legacy `_failed` / `_changed` / `_result` prefixes removed.
- **Hard-fail extraction** — invalid paths raise `HookValidationError` and stop the workflow regardless of `failure_strategy`.
- **Breaking rename** — `SetToHook` → `StoreAsHook`, YAML key `set_to` → `store_as`; all docs and tests updated.

## Hook behavior changes

| Before (`set_to`) | After (`store_as`) |
|---|---|
| Skipped storage on failed tasks | Stores on failed tasks when paths resolve |
| Simple mode stored full `Result` | Simple mode stores `Result.result` |
| `_failed`, `_changed`, `_result` path prefixes | Use `failed`, `changed`, `result` |
| Soft/ambiguous extraction | Hard-fail via `HookValidationError` |
| Silent missing context | `HookError` for missing `vars_manager` or host `Result` |

**Failure-path pattern** (now documented and tested at all three layers):

```yaml
store_as:
  step_failed: failed
# ...
if: "{{ step_failed }}"
```

## Tests & lab infrastructure

- **Unit** — ~40 `store_as` tests: failure-path, hybrid extraction, simple ≡ `result`, collision order, skipped hosts, conditional rollback workflow.
- **Integration** — E2E simple-mode equivalence; failure-path workflow via `nornflow init` + static fixtures.
- **Containerlab** — Phase A now runs `nornflow init`, merges static fixtures from `tests/integration/fixtures/common/` and `tests/integration/containerlab/fixtures/overlay/`, injects `hosts.yaml` only; adds `vars_all_levels.yaml` (env → runtime precedence + j2 filters) and failure-path live workflow.

Reviewers can open workflow/blueprint YAML under those fixture dirs instead of reading Python string builders.

## Documentation

- Full **`store_as`** section in hooks guide (simple mode, paths, collisions, failure-path).
- **`failure_strategies.md`** — `store_as` extraction errors are outside failure-strategy control.
- Remaining guides updated (`variables_basics`, `core_concepts`, `quick_start`, etc.).
- **`tests/README.md`** — Phase A/B/C breakdown for containerlab.

## Other

- `_raise_validation()` helper centralizes `HookValidationError` raises in `store_as.py`.
- Minor touch-ups in `nornflow.py` / `vars/manager.py` for renamed hook references.

## Breaking changes

Workflows using `set_to` or `_failed` / `_changed` / `_result` paths must migrate to `store_as` and bare `failed` / `changed` / `result`. Simple-mode consumers expecting a full `Result` object must switch to extraction paths or read `Result.result` fields directly.