### PR TITLE
feat: add nornflow validate CLI and pre-1.0 core fixes

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,3 +49,4 @@ NornFlow promotes collaboration between developers and network engineers:
 - [Jinja2 Filters](https://github.com/theandrelima/nornflow/blob/main/docs/jinja2_filters.md) - Advanced template manipulation
 - [Hooks Guide](https://github.com/theandrelima/nornflow/blob/main/docs/hooks_guide.md) - Extend task behavior with custom hooks
 - [API Reference](https://github.com/theandrelima/nornflow/blob/main/docs/api_reference.md) - For developers extending NornFlow
+- [Testing Guide](tests/README.md) - Test tiers, CI defaults, and maintainer cEOS lab integration tests

--- a/docs/quick_start.md
+++ b/docs/quick_start.md
@@ -203,6 +203,11 @@ Run it:
 nornflow run backup_configs.yaml
 ```
 
+Validate task-level errors from a workflow without executing tasks or contacting devices:
+```bash
+nornflow validate backup_configs.yaml
+```
+
 ## Using Variables
 
 ### Workflow-Level Variables

--- a/nornflow/builder.py
+++ b/nornflow/builder.py
@@ -3,8 +3,8 @@ from typing import Any
 
 from pydantic_serdes.utils import load_file_to_dict
 
-from nornflow.constants import FailureStrategy
-from nornflow.exceptions import InitializationError, ResourceError, SettingsError
+from nornflow.constants import FailureStrategy, NORNFLOW_SUPPORTED_YAML_EXTENSIONS
+from nornflow.exceptions import InitializationError, ResourceError, SettingsError, WorkflowError
 from nornflow.logger import logger
 from nornflow.models import WorkflowModel
 from nornflow.nornflow import NornFlow
@@ -162,6 +162,34 @@ class NornFlowBuilder:
         """
         self._workflow = (workflow_name, "name")
         return self
+
+    def with_workflow_reference(self, reference: str) -> "NornFlowBuilder":
+        """Set workflow from a YAML file path or workflows catalog name.
+
+        If reference resolves to an existing path, load that file. Otherwise resolve
+        the name through the workflows catalog (same behavior as 'nornflow run').
+
+        Args:
+            reference: Path to a workflow YAML if it exists on disk; otherwise the workflow's
+            catalog name (typically the .yaml filename).
+
+        Returns:
+            The builder instance for method chaining.
+
+        Raises:
+            WorkflowError: If reference does not end with a supported YAML extension.
+        """
+        if not any(reference.endswith(ext) for ext in NORNFLOW_SUPPORTED_YAML_EXTENSIONS):
+            raise WorkflowError(
+                f"Workflow reference must end with one of {NORNFLOW_SUPPORTED_YAML_EXTENSIONS}: "
+                f"{reference}",
+                component="NornFlowBuilder",
+            )
+
+        target_path = Path(reference)
+        if target_path.exists():
+            return self.with_workflow_path(str(target_path.resolve()))
+        return self.with_workflow_name(reference)
 
     def with_processors(self, processors: list[dict[str, Any]]) -> "NornFlowBuilder":
         """

--- a/nornflow/cli/entrypoint.py
+++ b/nornflow/cli/entrypoint.py
@@ -1,6 +1,6 @@
 import typer
 
-from nornflow.cli import init, run, show
+from nornflow.cli import init, run, show, validate
 
 app = typer.Typer(
     help="NornFlow is a workflow orchestration tool for Network Automation built around Nornir.",
@@ -34,6 +34,7 @@ def main(
 app.command()(init.init)
 app.command()(run.run)
 app.command()(show.show)
+app.command()(validate.validate)
 
 if __name__ == "__main__":
     app()

--- a/nornflow/cli/exceptions.py
+++ b/nornflow/cli/exceptions.py
@@ -70,3 +70,7 @@ class CLIRunError(NornFlowCLIError):
 
 class CLIInitError(NornFlowCLIError):
     """Raised when there are errors initializing resources via CLI."""
+
+
+class CLIValidateError(NornFlowCLIError):
+    """Raised when static workflow validation fails via CLI."""

--- a/nornflow/cli/run.py
+++ b/nornflow/cli/run.py
@@ -2,7 +2,6 @@ import ast
 import re
 import sys
 from datetime import datetime
-from pathlib import Path
 from typing import Any
 
 import typer
@@ -343,12 +342,7 @@ def get_nornflow_builder(
         builder.with_kwargs(dry_run=dry_run)
 
     if any(target.endswith(ext) for ext in NORNFLOW_SUPPORTED_YAML_EXTENSIONS):
-        target_path = Path(target)
-        if target_path.exists():
-            absolute_path = target_path.resolve()
-            builder.with_workflow_path(str(absolute_path))
-        else:
-            builder.with_workflow_name(target)
+        builder.with_workflow_reference(target)
     else:
         timestamp = datetime.now().strftime("%d-%m-%Y %H-%M-%S")
         workflow_dict = {

--- a/nornflow/cli/validate.py
+++ b/nornflow/cli/validate.py
@@ -1,0 +1,110 @@
+"""CLI command for static workflow validation."""
+
+import sys
+from pathlib import Path
+
+import typer
+from rich.console import Console
+from rich.panel import Panel
+from rich.table import Table
+
+from nornflow import NornFlowBuilder
+from nornflow.cli.exceptions import CLIValidateError
+from nornflow.exceptions import NornFlowError, WorkflowError, WorkflowValidationError
+from nornflow.nornflow import NornFlow
+
+app = typer.Typer(help="Validate NornFlow workflows without executing tasks")
+_console = Console(stderr=True)
+
+
+def show_validation_issues(workflow_path: str, exc: WorkflowValidationError) -> None:
+    """Render collected task validation issues as a single Rich table.
+
+    Args:
+        workflow_path: Path to the workflow file that was validated.
+        exc: Exception carrying all collected validation issues.
+    """
+    table = Table(
+        show_header=True,
+        header_style="bold red",
+        title=f"{len(exc.issues)} validation error(s) in {workflow_path}",
+    )
+    table.add_column("#", style="dim", width=4)
+    table.add_column("Task ref", style="cyan", no_wrap=True)
+    table.add_column("Task", style="cyan")
+    table.add_column("Check", style="yellow", no_wrap=True)
+    table.add_column("Problem")
+
+    for issue in exc.issues:
+        table.add_row(
+            str(issue.task_index),
+            issue.task_ref,
+            issue.task_name,
+            issue.category,
+            issue.message,
+        )
+
+    _console.print(Panel(table, title="[red]NornFlow Validation Failed[/]", border_style="red"))
+
+
+def build_nornflow_for_validate(settings_file: str, workflow: str) -> NornFlow:
+    """Build NornFlow with a fully assembled workflow, ready for validate_workflow().
+
+    Uses the same path as run: settings load, blueprint expansion, TaskModel build.
+    Call validate_workflow() only after build() returns.
+
+    Args:
+        settings_file: Optional path to nornflow settings YAML.
+        workflow: Workflow file path or catalog workflow name.
+
+    Returns:
+        NornFlow with catalogs loaded and workflow assembled.
+
+    Raises:
+        CLIValidateError: When the workflow reference is invalid or assembly fails.
+    """
+    builder = NornFlowBuilder()
+    if settings_file:
+        builder.with_settings_path(settings_file)
+
+    try:
+        builder.with_workflow_reference(workflow)
+    except WorkflowError as exc:
+        raise CLIValidateError(message=str(exc), original_exception=exc) from exc
+
+    workflow_label = Path(workflow).name if Path(workflow).exists() else workflow
+
+    try:
+        return builder.build()
+    except NornFlowError as exc:
+        raise CLIValidateError(
+            message=f"Failed to assemble workflow '{workflow_label}': {exc}",
+            original_exception=exc,
+        ) from exc
+
+
+@app.command()
+def validate(
+    ctx: typer.Context,
+    workflow: str = typer.Argument(..., help="Workflow file path or catalog workflow name"),
+) -> None:
+    """Validate a workflow file without running tasks or contacting devices."""
+    settings = ctx.obj.get("settings", "")
+
+    try:
+        nornflow = build_nornflow_for_validate(settings, workflow)
+        nornflow.validate_workflow()
+        workflow_name = nornflow.workflow.name if nornflow.workflow else workflow
+        typer.secho(f"Validation passed: {workflow_name}", fg=typer.colors.GREEN)
+    except WorkflowValidationError as exc:
+        show_validation_issues(workflow, exc)
+        sys.exit(1)
+    except NornFlowError as exc:
+        CLIValidateError(
+            message=f"Validation failed for '{workflow}': {exc}",
+            original_exception=exc,
+        ).show()
+        sys.exit(1)
+    except CLIValidateError as exc:
+        exc.show()
+        sys.exit(exc.code)

--- a/nornflow/cli/validate.py
+++ b/nornflow/cli/validate.py
@@ -99,12 +99,12 @@ def validate(
     except WorkflowValidationError as exc:
         show_validation_issues(workflow, exc)
         sys.exit(1)
+    except CLIValidateError as exc:
+        exc.show()
+        sys.exit(exc.code)
     except NornFlowError as exc:
         CLIValidateError(
             message=f"Validation failed for '{workflow}': {exc}",
             original_exception=exc,
         ).show()
         sys.exit(1)
-    except CLIValidateError as exc:
-        exc.show()
-        sys.exit(exc.code)

--- a/nornflow/exceptions.py
+++ b/nornflow/exceptions.py
@@ -5,7 +5,10 @@ This module defines the core exceptions used throughout the NornFlow application
 organized hierarchically with clear inheritance paths.
 """
 
-from typing import Any
+from typing import Any, TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from nornflow.validation import ValidationIssue
 
 ###############################################################################
 # ROOT EXCEPTION
@@ -148,6 +151,14 @@ class TaskError(WorkflowError):
 
     def __init__(self, message: str = "", task_name: str = "", **kwargs):
         super().__init__(message, task_name=task_name, **kwargs)
+
+
+class WorkflowValidationError(WorkflowError):
+    """Raised when static workflow validation finds one or more task-level problems."""
+
+    def __init__(self, issues: "list[ValidationIssue]"):
+        self.issues = issues
+        super().__init__(f"Workflow validation failed with {len(issues)} error(s)")
 
 
 class FilterError(WorkflowError):

--- a/nornflow/j2/core.py
+++ b/nornflow/j2/core.py
@@ -86,13 +86,29 @@ class Jinja2Service:
         instance.environment.filters.update(filters)
 
     @classmethod
+    def reset(cls) -> None:
+        """Clear the singleton so the next use rebuilds environment and catalogs.
+
+        Intended for tests and embedded use when multiple ``NornFlow`` instances are
+        created sequentially in one process.
+        """
+        with cls._lock:
+            if cls._instance is not None:
+                cls._instance.compile_template.cache_clear()
+            cls._instance = None
+            cls._initialized = False
+
+    @classmethod
     def initialize_with_settings(
         cls, settings: NornFlowSettings, package_loader: PackageLoader | None = None
     ) -> None:
         """Initialize the service with NornFlow settings, registering custom filters.
 
         Registers j2_filters from local directories first, then from packages.
+        Rebuilds the singleton on each call so filter catalogs do not leak between
+        successive ``NornFlow`` initializations in the same process.
         """
+        cls.reset()
         locations = [(LOCAL_NAMESPACE, str(path), TIER_LOCAL) for path in settings.local_j2_filters]
         if package_loader:
             locations.extend(

--- a/nornflow/models/workflow.py
+++ b/nornflow/models/workflow.py
@@ -56,7 +56,10 @@ class WorkflowModel(NornFlowBaseModel):
             logger.error("Workflow creation failed: missing 'workflow' key in dict_args")
             raise WorkflowError("Workflow file must have 'workflow' as a root-level key.")
 
-        workflow_dict = dict_args["workflow"]
+        #shallow-copy of dict_args["workflow"] to avoid mutating that object
+        workflow_dict = dict(dict_args["workflow"])
+        if workflow_dict.get("tasks"):
+            workflow_dict["tasks"] = list(workflow_dict["tasks"])
 
         if "tasks" not in workflow_dict:
             workflow_dict["tasks"] = []

--- a/nornflow/nornflow.py
+++ b/nornflow/nornflow.py
@@ -46,6 +46,7 @@ from nornflow.utils import (
     print_workflow_overview,
     process_filter,
 )
+from nornflow.validation import validate_workflow_tasks
 from nornflow.vars.manager import NornFlowVariablesManager
 from nornflow.vars.processors import NornFlowVariableProcessor
 
@@ -1254,6 +1255,32 @@ class NornFlow:
             return 101
 
         return 0
+
+    def validate_workflow(self, workflow: WorkflowModel | None = None) -> None:
+        """Validate a fully assembled workflow without executing tasks or Nornir I/O.
+
+        Precondition: the workflow must already be loaded and fully assembled. Use
+        NornFlowBuilder.with_workflow_path() and build(), or WorkflowModel.create()
+        with blueprint kwargs, before calling this. Do not call on raw dicts,
+        unexpanded blueprints, or an unresolved workflow name string.
+
+        Assembly errors are raised during create() or build(). This method runs a
+        second pass via validate_workflow_tasks().
+
+        Args:
+            workflow: Workflow to validate; defaults to the instance workflow.
+
+        Raises:
+            WorkflowError: When no workflow is loaded or there are no tasks after
+                expansion.
+            WorkflowValidationError: When one or more task-level problems were found.
+        """
+        target = workflow if workflow is not None else self._workflow
+
+        if target is None:
+            raise WorkflowError("No workflow loaded to validate", component="NornFlow")
+
+        validate_workflow_tasks(self, target)
 
     def run(self) -> int:
         """

--- a/nornflow/validation.py
+++ b/nornflow/validation.py
@@ -1,0 +1,152 @@
+"""Static workflow validation without contacting devices or running Nornir tasks."""
+
+import inspect
+from dataclasses import dataclass
+from typing import Any, TYPE_CHECKING
+
+from nornflow.exceptions import (
+    AssetAmbiguityError,
+    AssetNotFoundError,
+    NornFlowError,
+    TaskError,
+    WorkflowError,
+    WorkflowValidationError,
+)
+from nornflow.models import WorkflowModel
+
+if TYPE_CHECKING:
+    from nornflow.nornflow import NornFlow
+
+# Task parameters Nornir or task decorators inject; not supplied from workflow YAML.
+_EXCLUDED_TASK_PARAMS = frozenset({"task", "node"})
+
+
+@dataclass
+class ValidationIssue:
+    """One task-level problem found during static workflow validation."""
+
+    task_index: int
+    task_ref: str
+    task_name: str
+    category: str
+    message: str
+
+
+def validate_task_args(task_name: str, task_func: Any, args: dict[str, Any] | None) -> None:
+    """Ensure required task parameters are present in workflow args.
+
+    Args:
+        task_name: Catalog task reference from the workflow.
+        task_func: Resolved Nornir task callable.
+        args: Task args from the workflow YAML.
+
+    Raises:
+        TaskError: When a required workflow-supplied parameter is missing.
+    """
+    signature = inspect.signature(task_func)
+    provided = set(args or {})
+    missing = []
+
+    for param_name, param in signature.parameters.items():
+        if param_name in _EXCLUDED_TASK_PARAMS:
+            continue
+        if param.kind in (inspect.Parameter.VAR_KEYWORD, inspect.Parameter.VAR_POSITIONAL):
+            continue
+        if param.default is inspect.Parameter.empty and param_name not in provided:
+            missing.append(param_name)
+
+    if missing:
+        joined = ", ".join(f"'{name}'" for name in missing)
+        raise TaskError(
+            f"Missing required argument(s): {joined}",
+            task_name=task_name,
+        )
+
+
+def validate_workflow_tasks(nornflow: "NornFlow", workflow: WorkflowModel) -> None:
+    """Resolve tasks, validate args, and run hook configuration checks.
+
+    Precondition: workflow must be a finished WorkflowModel. YAML must already be
+    parsed, blueprints expanded, and each task built via TaskModel.create(). Do not
+    call this on raw dicts or unexpanded blueprint entries.
+
+    Assembly errors (missing blueprints, circular chains, invalid workflow shape)
+    belong to WorkflowModel.create() or build(), not this function. This is a second
+    pass: catalog resolution, required args, and hook checks.
+
+    Every task is checked before raising. When any problem is found, raises
+    WorkflowValidationError with all collected issues.
+
+    Args:
+        nornflow: Initialized NornFlow instance with catalogs loaded.
+        workflow: Fully expanded workflow model.
+
+    Raises:
+        WorkflowValidationError: When one or more task-level problems were found.
+        WorkflowError: When the workflow has no tasks after expansion.
+    """
+    if not workflow.tasks:
+        raise WorkflowError("Workflow has no tasks after blueprint expansion", component="NornFlow")
+
+    catalog = nornflow.tasks_catalog
+    issues: list[ValidationIssue] = []
+
+    for index, task in enumerate(workflow.tasks, start=1):
+        try:
+            task_func = catalog.resolve(task.name)
+        except AssetAmbiguityError as exc:
+            issues.append(
+                ValidationIssue(
+                    task_index=index,
+                    task_ref=task.canonical_id,
+                    task_name=task.name,
+                    category="catalog",
+                    message=(
+                        f"Ambiguous task reference. Use a qualified name. "
+                        f"Candidates: {', '.join(sorted(exc.candidates))}"
+                    ),
+                )
+            )
+            continue
+        except AssetNotFoundError:
+            issues.append(
+                ValidationIssue(
+                    task_index=index,
+                    task_ref=task.canonical_id,
+                    task_name=task.name,
+                    category="catalog",
+                    message="Task not found in tasks catalog",
+                )
+            )
+            continue
+
+        task_args = dict(task.args) if task.args else None
+        try:
+            validate_task_args(task.name, task_func, task_args)
+        except TaskError as exc:
+            issues.append(
+                ValidationIssue(
+                    task_index=index,
+                    task_ref=task.canonical_id,
+                    task_name=task.name,
+                    category="args",
+                    message=str(exc),
+                )
+            )
+            continue
+
+        try:
+            task.run_hook_validations()
+        except NornFlowError as exc:
+            issues.append(
+                ValidationIssue(
+                    task_index=index,
+                    task_ref=task.canonical_id,
+                    task_name=task.name,
+                    category="hooks",
+                    message=str(exc),
+                )
+            )
+
+    if issues:
+        raise WorkflowValidationError(issues)

--- a/tests/README.md
+++ b/tests/README.md
@@ -153,6 +153,7 @@ Implemented in `provision_lab_environment()` (`lab_project.py`), triggered by th
 
 - In-process catalog validation via `lab_runner.py phase-b` (`test_catalog_and_package.py`).
 - `nornflow show` CLI checks for tasks, filters, workflows, blueprints, j2-filters, and hooks (`test_nornflow_show.py`).
+- `nornflow validate` static workflow checks — success and failure fixtures (`test_validate.py`).
 - `nornflow run vars_all_levels.yaml`: env, global, domain, workflow, CLI, and runtime vars plus j2 filters (`test_vars_all_levels.py`, echo-only; file under `workflows/lab/` for domain scoping).
 
 **Phase C: live workflow runs** (requires reachable lab):

--- a/tests/integration/containerlab/constants.py
+++ b/tests/integration/containerlab/constants.py
@@ -29,6 +29,11 @@ LAB_READONLY_BLUEPRINT = "lab_readonly_snapshot.yaml"
 # File lives under workflows/lab/ for domain vars; catalog key is the filename only.
 LAB_VARS_ALL_LEVELS_WORKFLOW = "vars_all_levels.yaml"
 
+LAB_VALIDATE_OK_WORKFLOW = "lab_validate_ok.yaml"
+LAB_VALIDATE_BAD_TASK_WORKFLOW = "lab_validate_bad_task.yaml"
+LAB_VALIDATE_BAD_ARGS_WORKFLOW = "lab_validate_bad_args.yaml"
+LAB_VALIDATE_BLUEPRINT_LOOP_WORKFLOW = "lab_validate_blueprint_loop.yaml"
+
 # Env var name set at test runtime for vars-all-levels workflow (NORNFLOW_VAR_env_marker).
 LAB_VARS_ENV_VAR = "env_marker"
 LAB_VARS_ENV_VALUE = "ENV_OK"

--- a/tests/integration/containerlab/fixtures/overlay/blueprints/lab_validate_loop_a.yaml
+++ b/tests/integration/containerlab/fixtures/overlay/blueprints/lab_validate_loop_a.yaml
@@ -1,0 +1,2 @@
+tasks:
+  - blueprint: lab_validate_loop_b.yaml

--- a/tests/integration/containerlab/fixtures/overlay/blueprints/lab_validate_loop_b.yaml
+++ b/tests/integration/containerlab/fixtures/overlay/blueprints/lab_validate_loop_b.yaml
@@ -1,0 +1,2 @@
+tasks:
+  - blueprint: lab_validate_loop_a.yaml

--- a/tests/integration/containerlab/fixtures/overlay/workflows/lab_validate_bad_args.yaml
+++ b/tests/integration/containerlab/fixtures/overlay/workflows/lab_validate_bad_args.yaml
@@ -1,0 +1,5 @@
+workflow:
+  name: Containerlab validate bad args
+  tasks:
+    - name: nornflow.echo
+      args: {}

--- a/tests/integration/containerlab/fixtures/overlay/workflows/lab_validate_bad_task.yaml
+++ b/tests/integration/containerlab/fixtures/overlay/workflows/lab_validate_bad_task.yaml
@@ -1,0 +1,5 @@
+workflow:
+  name: Containerlab validate bad task
+  tasks:
+    - name: nornflow.this_task_does_not_exist
+      args: {}

--- a/tests/integration/containerlab/fixtures/overlay/workflows/lab_validate_blueprint_loop.yaml
+++ b/tests/integration/containerlab/fixtures/overlay/workflows/lab_validate_blueprint_loop.yaml
@@ -1,0 +1,4 @@
+workflow:
+  name: Containerlab validate blueprint loop
+  tasks:
+    - blueprint: lab_validate_loop_a.yaml

--- a/tests/integration/containerlab/fixtures/overlay/workflows/lab_validate_ok.yaml
+++ b/tests/integration/containerlab/fixtures/overlay/workflows/lab_validate_ok.yaml
@@ -1,0 +1,10 @@
+workflow:
+  name: Containerlab validate OK
+  description: Valid workflow for nornflow validate integration tests.
+  tasks:
+    - name: nornflow.echo
+      args:
+        msg: "validate ok"
+
+    - blueprint: lab_readonly_snapshot.yaml
+      single: true

--- a/tests/integration/containerlab/test_validate.py
+++ b/tests/integration/containerlab/test_validate.py
@@ -1,0 +1,46 @@
+"""Phase B: nornflow validate CLI against lab fixture workflows (no device I/O)."""
+
+import subprocess
+
+import pytest
+
+from tests.integration.containerlab.conftest import run_nornflow_cli
+from tests.integration.containerlab.constants import (
+    LAB_VALIDATE_BAD_ARGS_WORKFLOW,
+    LAB_VALIDATE_BAD_TASK_WORKFLOW,
+    LAB_VALIDATE_BLUEPRINT_LOOP_WORKFLOW,
+    LAB_VALIDATE_OK_WORKFLOW,
+)
+from tests.integration.containerlab.lab_project import LabEnvironment
+
+
+def _combined_output(result: subprocess.CompletedProcess[str]) -> str:
+    return f"{result.stdout or ''}\n{result.stderr or ''}"
+
+
+def test_validate_ok_workflow(lab_environment: LabEnvironment) -> None:
+    """Valid lab workflow passes static validation."""
+    result = run_nornflow_cli(lab_environment, ["validate", LAB_VALIDATE_OK_WORKFLOW])
+    output = _combined_output(result)
+    assert result.returncode == 0, output
+    assert "Validation passed" in output
+
+
+@pytest.mark.parametrize(
+    ("workflow", "needle"),
+    [
+        (LAB_VALIDATE_BAD_TASK_WORKFLOW, "not found"),
+        (LAB_VALIDATE_BAD_ARGS_WORKFLOW, "missing required argument"),
+        (LAB_VALIDATE_BLUEPRINT_LOOP_WORKFLOW, "Circular dependency detected"),
+    ],
+)
+def test_validate_failure_workflows(
+    lab_environment: LabEnvironment,
+    workflow: str,
+    needle: str,
+) -> None:
+    """Invalid lab workflows fail validate with actionable errors."""
+    result = run_nornflow_cli(lab_environment, ["validate", workflow])
+    output = _combined_output(result)
+    assert result.returncode != 0, output
+    assert needle.lower() in output.lower(), output

--- a/tests/unit/cli/test_run.py
+++ b/tests/unit/cli/test_run.py
@@ -355,21 +355,12 @@ class TestNornflowBuilderIntegration:
         assert call_args["workflow"]["name"].startswith("Task test_task - exec")
         assert call_args["workflow"]["tasks"] == [{"name": "test_task", "args": {"arg1": "value1"}}]
 
-    @patch("nornflow.cli.run.Path")
     @patch("nornflow.cli.run.NornFlowBuilder")
-    def test_get_nornflow_builder_workflow_path(self, mock_builder_cls, mock_path_cls):
+    def test_get_nornflow_builder_workflow_path(self, mock_builder_cls):
         """Test building a NornFlow object for a workflow file path."""
-        # Setup mock path to simulate existing file
-        mock_path = MagicMock()
-        mock_path.exists.return_value = True
-        mock_path.resolve.return_value = "absolute/path/to/workflow.yaml"
-        mock_path_cls.return_value = mock_path
-
-        # Setup mock builder
         mock_builder = MagicMock()
         mock_builder_cls.return_value = mock_builder
 
-        # Call function
         get_nornflow_builder(
             "workflow.yaml",
             None,
@@ -377,29 +368,19 @@ class TestNornflowBuilderIntegration:
             ""  # Use empty string to skip settings loading
         )
 
-        # Verify builder methods were called
         mock_builder.with_settings_path.assert_not_called()  # Since settings_file is empty
         mock_builder.with_filters.assert_called_once_with({"hosts": ["host1"]})
-        mock_builder.with_workflow_path.assert_called_once_with("absolute/path/to/workflow.yaml")
+        mock_builder.with_workflow_reference.assert_called_once_with("workflow.yaml")
 
-    @patch("nornflow.cli.run.Path")
     @patch("nornflow.cli.run.NornFlowBuilder")
-    def test_get_nornflow_builder_workflow_name_with_yaml_extension(self, mock_builder_cls, mock_path_cls):
+    def test_get_nornflow_builder_workflow_name_with_yaml_extension(self, mock_builder_cls):
         """Test building with a workflow name that has .yaml extension but doesn't exist as file."""
-        # Setup mock path for non-existent yaml file
-        mock_path = MagicMock()
-        mock_path.exists.return_value = False
-        mock_path_cls.return_value = mock_path
-
-        # Setup mock builder
         mock_builder = MagicMock()
         mock_builder_cls.return_value = mock_builder
 
-        # Call function
         get_nornflow_builder("nonexistent.yaml", None, None, "")
 
-        # Should call with_workflow_name since file doesn't exist
-        mock_builder.with_workflow_name.assert_called_once_with("nonexistent.yaml")
+        mock_builder.with_workflow_reference.assert_called_once_with("nonexistent.yaml")
 
     @patch("nornflow.cli.run.NornFlowBuilder")
     def test_get_nornflow_builder_task_name_without_extension(self, mock_builder_cls):
@@ -556,17 +537,9 @@ class TestProcessorIntegration:
 class TestCLIWorkflowOverrides:
     """Test CLI overrides for workflow settings."""
 
-    @patch("nornflow.cli.run.Path")
     @patch("nornflow.cli.run.NornFlowBuilder")
-    def test_inventory_filters_override(self, mock_builder_cls, mock_path_cls):
+    def test_inventory_filters_override(self, mock_builder_cls):
         """Test that CLI inventory filters override workflow filters."""
-        # Setup mock path
-        mock_path = MagicMock()
-        mock_path.exists.return_value = True
-        mock_path.resolve.return_value = "/path/to/workflow.yaml"
-        mock_path_cls.return_value = mock_path
-
-        # Setup mock builder
         mock_builder = MagicMock()
         mock_builder_cls.return_value = mock_builder
 

--- a/tests/unit/cli/test_validate.py
+++ b/tests/unit/cli/test_validate.py
@@ -1,0 +1,288 @@
+"""Unit tests for nornflow validate CLI and workflow validation."""
+
+from pathlib import Path
+
+import pytest
+from typer.testing import CliRunner
+
+from nornflow.cli.entrypoint import app
+from nornflow.cli.exceptions import CLIValidateError
+from nornflow.cli.validate import build_nornflow_for_validate
+from nornflow.exceptions import TaskError, WorkflowError, WorkflowValidationError
+from nornflow.j2 import Jinja2Service
+from nornflow.models import WorkflowModel
+from nornflow.nornflow import NornFlow
+from nornflow.settings import NornFlowSettings
+
+
+def _write_minimal_project(root: Path) -> Path:
+    """Create a minimal NornFlow project tree for validate tests.
+
+    Args:
+        root: Directory that becomes the project root.
+
+    Returns:
+        Path to the generated nornflow.yaml settings file.
+    """
+    (root / "nornir_configs").mkdir()
+    (root / "nornir_configs" / "config.yaml").write_text(
+        """inventory:
+  plugin: SimpleInventory
+  options:
+    host_file: nornir_configs/hosts.yaml
+runner:
+  plugin: threaded
+  options:
+    num_workers: 1
+"""
+    )
+    (root / "nornir_configs" / "hosts.yaml").write_text("localhost:\n  hostname: 127.0.0.1\n")
+    for dirname in ("workflows", "blueprints", "vars", "tasks", "filters", "hooks", "j2_filters"):
+        (root / dirname).mkdir()
+    (root / "vars" / "defaults.yaml").write_text("{}\n")
+
+    settings_path = root / "nornflow.yaml"
+    settings_path.write_text(
+        f"""nornir_config_file: nornir_configs/config.yaml
+local_workflows:
+  - workflows
+local_blueprints:
+  - blueprints
+vars_dir: vars
+processors:
+  - class: nornflow.builtins.DefaultNornFlowProcessor
+"""
+    )
+    return settings_path
+
+
+@pytest.fixture
+def validate_project(tmp_path: Path) -> Path:
+    """Minimal project root directory."""
+    _write_minimal_project(tmp_path)
+    return tmp_path
+
+
+class TestBuildNornflowForValidate:
+    """Tests for validate CLI assembly helper."""
+
+    def test_missing_workflow_raises(self, validate_project: Path) -> None:
+        settings = validate_project / "nornflow.yaml"
+        with pytest.raises(CLIValidateError, match="not found"):
+            build_nornflow_for_validate(str(settings), "missing.yaml")
+
+    def test_non_yaml_extension_raises(self, validate_project: Path) -> None:
+        settings = validate_project / "nornflow.yaml"
+        bad_path = validate_project / "workflows" / "notes.txt"
+        bad_path.write_text("not yaml\n")
+        with pytest.raises(CLIValidateError, match="must end with"):
+            build_nornflow_for_validate(str(settings), str(bad_path))
+
+
+class TestValidateCLI:
+    """End-to-end CLI tests for nornflow validate."""
+
+    @pytest.fixture
+    def runner(self) -> CliRunner:
+        return CliRunner()
+
+    def test_validate_success(self, validate_project: Path, runner: CliRunner) -> None:
+        workflow = validate_project / "workflows" / "ok.yaml"
+        workflow.write_text(
+            """workflow:
+  name: ok
+  tasks:
+    - name: nornflow.echo
+      args:
+        msg: hello
+"""
+        )
+        result = runner.invoke(
+            app,
+            ["--settings", str(validate_project / "nornflow.yaml"), "validate", str(workflow)],
+        )
+        assert result.exit_code == 0, result.output
+        assert "Validation passed" in result.output
+
+    def test_validate_success_by_catalog_name(self, validate_project: Path, runner: CliRunner) -> None:
+        workflow = validate_project / "workflows" / "ok.yaml"
+        workflow.write_text(
+            """workflow:
+  name: ok
+  tasks:
+    - name: nornflow.echo
+      args:
+        msg: hello
+"""
+        )
+        result = runner.invoke(
+            app,
+            ["--settings", str(validate_project / "nornflow.yaml"), "validate", "ok.yaml"],
+            catch_exceptions=False,
+        )
+        assert result.exit_code == 0, result.output
+        assert "Validation passed" in result.output
+
+    def test_validate_unknown_task_fails(self, validate_project: Path, runner: CliRunner) -> None:
+        workflow = validate_project / "workflows" / "bad_task.yaml"
+        workflow.write_text(
+            """workflow:
+  name: bad task
+  tasks:
+    - name: nornflow.no_such_task
+"""
+        )
+        result = runner.invoke(
+            app,
+            ["--settings", str(validate_project / "nornflow.yaml"), "validate", str(workflow)],
+        )
+        combined = (result.output + getattr(result, "stderr", "")).lower()
+        assert result.exit_code == 1, result.output
+        assert "validation failed" in combined or "validation error" in combined
+
+    def test_validate_missing_args_fails(self, validate_project: Path, runner: CliRunner) -> None:
+        workflow = validate_project / "workflows" / "bad_args.yaml"
+        workflow.write_text(
+            """workflow:
+  name: bad args
+  tasks:
+    - name: nornflow.echo
+      args: {}
+"""
+        )
+        result = runner.invoke(
+            app,
+            ["--settings", str(validate_project / "nornflow.yaml"), "validate", str(workflow)],
+        )
+        combined = (result.output + getattr(result, "stderr", "")).lower()
+        assert result.exit_code == 1, result.output
+        assert "args" in combined
+        assert "'msg'" in combined
+
+    def test_validate_reports_all_task_errors(self, validate_project: Path, runner: CliRunner) -> None:
+        workflow = validate_project / "workflows" / "many_errors.yaml"
+        workflow.write_text(
+            """workflow:
+  name: many errors
+  tasks:
+    - name: nornflow.no_such_task
+    - name: nornflow.echo
+      args: {}
+    - name: nornflow.echo
+      args:
+        message: hello
+"""
+        )
+        result = runner.invoke(
+            app,
+            ["--settings", str(validate_project / "nornflow.yaml"), "validate", str(workflow)],
+        )
+        combined = (result.output + getattr(result, "stderr", "")).lower()
+        assert result.exit_code == 1, result.output
+        assert "3 validation error" in combined
+        assert "catalog" in combined
+        assert combined.count("args") >= 2
+
+    def test_validate_circular_blueprint_fails(self, validate_project: Path, runner: CliRunner) -> None:
+        blueprint_dir = validate_project / "blueprints"
+        (blueprint_dir / "loop_a.yaml").write_text("tasks:\n  - blueprint: loop_b.yaml\n")
+        (blueprint_dir / "loop_b.yaml").write_text("tasks:\n  - blueprint: loop_a.yaml\n")
+        workflow = validate_project / "workflows" / "loop.yaml"
+        workflow.write_text(
+            """workflow:
+  name: loop
+  tasks:
+    - blueprint: loop_a.yaml
+"""
+        )
+        result = runner.invoke(
+            app,
+            ["--settings", str(validate_project / "nornflow.yaml"), "validate", str(workflow)],
+            catch_exceptions=False,
+        )
+        assert result.exit_code == 1, result.output
+        assert "circular dependency detected" in result.output.lower()
+
+
+class TestNornFlowValidateWorkflow:
+    """In-process validate_workflow API tests."""
+
+    def test_validate_workflow_without_loaded_workflow_raises(self) -> None:
+        settings = NornFlowSettings(nornir_config_file="dummy.yaml")
+        nornflow = NornFlow(nornflow_settings=settings)
+        with pytest.raises(WorkflowError, match="No workflow loaded"):
+            nornflow.validate_workflow()
+
+    def test_validate_workflow_unknown_task(self, validate_project: Path) -> None:
+        settings = NornFlowSettings.load(
+            str(validate_project / "nornflow.yaml"),
+            base_dir=validate_project,
+        )
+        nornflow = NornFlow(nornflow_settings=settings)
+        workflow = WorkflowModel.create(
+            {
+                "workflow": {
+                    "name": "bad task",
+                    "tasks": [{"name": "nornflow.no_such_task"}],
+                }
+            }
+        )
+        with pytest.raises(WorkflowValidationError) as exc_info:
+            nornflow.validate_workflow(workflow)
+        assert len(exc_info.value.issues) == 1
+        assert exc_info.value.issues[0].category == "catalog"
+        assert exc_info.value.issues[0].message == "Task not found in tasks catalog"
+
+    def test_validate_workflow_checks_task_args(self, validate_project: Path) -> None:
+        settings = NornFlowSettings.load(
+            str(validate_project / "nornflow.yaml"),
+            base_dir=validate_project,
+        )
+        nornflow = NornFlow(nornflow_settings=settings)
+        workflow = WorkflowModel.create(
+            {
+                "workflow": {
+                    "name": "bad args",
+                    "tasks": [{"name": "nornflow.echo", "args": {}}],
+                }
+            }
+        )
+        with pytest.raises(WorkflowValidationError) as exc_info:
+            nornflow.validate_workflow(workflow)
+        assert len(exc_info.value.issues) == 1
+        assert exc_info.value.issues[0].category == "args"
+
+
+class TestJinja2ServiceReset:
+    """Ensure successive NornFlow inits do not leak custom j2 filters."""
+
+    def test_initialize_with_settings_replaces_custom_filters(self, tmp_path: Path) -> None:
+        filters_a = tmp_path / "filters_a"
+        filters_b = tmp_path / "filters_b"
+        filters_a.mkdir()
+        filters_b.mkdir()
+        (filters_a / "filter_a.py").write_text(
+            "def filter_a(value):\n    return f'a-{value}'\n"
+        )
+        (filters_b / "filter_b.py").write_text(
+            "def filter_b(value):\n    return f'b-{value}'\n"
+        )
+
+        settings_a = NornFlowSettings(
+            nornir_config_file="dummy.yaml",
+            local_j2_filters=[str(filters_a)],
+        )
+        settings_b = NornFlowSettings(
+            nornir_config_file="dummy.yaml",
+            local_j2_filters=[str(filters_b)],
+        )
+
+        Jinja2Service.initialize_with_settings(settings_a)
+        catalog = Jinja2Service().j2_filters_catalog
+        assert "local.filter_a" in catalog
+        assert "local.filter_b" not in catalog
+
+        Jinja2Service.initialize_with_settings(settings_b)
+        catalog = Jinja2Service().j2_filters_catalog
+        assert "local.filter_b" in catalog
+        assert "local.filter_a" not in catalog

--- a/tests/unit/models/test_workflow_model.py
+++ b/tests/unit/models/test_workflow_model.py
@@ -21,6 +21,18 @@ class TestWorkflowModel:
         assert workflow.name == "test_workflow"
         assert len(workflow.tasks) == 1
 
+    def test_create_does_not_mutate_input_workflow_dict(self, tmp_path):
+        """Blueprint expansion must not replace tasks in the caller's workflow dict."""
+        tasks = [{"name": "nornflow.echo", "args": {"msg": "hi"}}]
+        workflow_section = {"name": "immutable", "tasks": tasks}
+        workflow_dict = {"workflow": workflow_section}
+
+        WorkflowModel.create(workflow_dict)
+
+        assert len(tasks) == 1
+        assert isinstance(tasks[0], dict)
+        assert tasks[0]["name"] == "nornflow.echo"
+
     def test_create_missing_workflow_key(self):
         """Test error when workflow key missing."""
         with pytest.raises(WorkflowError, match="'workflow' as a root-level key"):


### PR DESCRIPTION
## Summary

- **`nornflow validate` CLI** — static, non-executing workflow checks using the same assembly path as `run` (settings/catalog load, blueprint expansion, `WorkflowModel` build). Assembly errors fail fast; task-level problems are collected and reported in a Rich table (catalog, args, hooks).
- **`NornFlowBuilder.with_workflow_reference()`** — shared path-vs-catalog workflow resolution for `run` and `validate`.
- **`WorkflowModel.create` shallow copy** — blueprint expansion no longer mutates the caller’s workflow dict.
- **`Jinja2Service.reset()`** — successive `NornFlow` inits in one process do not leak custom j2 filters.
- **Docs** — `nornflow validate` example in `docs/quick_start.md`; containerlab validate coverage noted in `tests/README.md`. Main `README.md` already links to the Testing Guide.

### Validation behavior (two phases)

1. **Assembly** (same as `run`): missing blueprints, circular blueprint chains, invalid YAML shape, unknown top-level task fields (e.g. legacy hook names) → fail-fast CLI error.
2. **Semantic pass**: unknown task, missing required workflow args, invalid hook configuration → collect-all `WorkflowValidationError` table.

Task arg checks skip framework-injected parameters (`task`, `node`) so package tasks like `nornflow_arista.get_facts` validate correctly without workflow YAML supplying connection objects.

