### PR TITLE
chore(release): promote develop to main for v1.0.0

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -26,7 +26,7 @@ jobs:
         python-version: ["3.10", "3.11", "3.12", "3.13", "3.14"]
 
     steps:
-    - uses: actions/checkout@v6
+    - uses: actions/checkout@v7
     
     - name: Set up Python ${{ matrix.python-version }}
       uses: actions/setup-python@v6

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,35 @@
+# Changelog
+
+All notable changes to this project are documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
+and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+## [Unreleased]
+
+## [1.0.0] - 2026-07-01
+
+First stable release. NornFlow now follows Semantic Versioning; the public
+API and CLI surface described in the documentation are considered stable.
+
+### Added
+- Declarative YAML workflow system (`workflow:` / `tasks:`) built on Nornir.
+- CLI: `init`, `run`, `show`, and `validate` commands.
+- Catalog system with namespace isolation and tier priority
+  (builtin > local > package) for six resource types
+  (tasks, filters, workflows, blueprints, j2-filters, hooks).
+- Packages system: installed Python packages contribute resources to catalogs.
+- Six-level variable precedence with device-isolated context and the `host.*` namespace.
+- Jinja2 templating service with builtin and namespaced custom filters.
+- Hook system with builtin hooks: `if`, `store_as`, `single`, `shush`.
+- Blueprints with recursive expansion and circular-dependency detection.
+- Failure strategies: `skip-failed`, `fail-fast`, `run-all`.
+- Output masking and redaction of sensitive values in CLI output and logs.
+- Documentation set under `docs/` and a maintainer testing guide under `tests/`.
+
+### Pre-1.0 history
+Versions 0.0.2 (2025-02-23) through 0.9.1 (2026-06-14) were pre-release and are
+not individually documented here. See the git tags for details.
+
+[Unreleased]: https://github.com/theandrelima/nornflow/compare/v1.0.0...HEAD
+[1.0.0]: https://github.com/theandrelima/nornflow/releases/tag/v1.0.0

--- a/README.md
+++ b/README.md
@@ -11,9 +11,6 @@
 [![Linter: Ruff](https://img.shields.io/endpoint?url=https://raw.githubusercontent.com/astral-sh/ruff/main/assets/badge/v2.json)](https://github.com/astral-sh/ruff)
 [![Installer: uv](https://img.shields.io/badge/installer-uv-blue)](https://github.com/astral-sh/uv)
 
-
-> **NornFlow is currently in pre-release.**
-
 ## What is NornFlow?
 NornFlow is a lightweight workflow orchestration framework built on top of [Nornir](https://github.com/nornir-automation/nornir), bringing structure and predictability to network automation projects.
 

--- a/nornflow/cli/entrypoint.py
+++ b/nornflow/cli/entrypoint.py
@@ -33,7 +33,7 @@ def main(
 # Register subcommands
 app.command()(init.init)
 app.command()(run.run)
-app.command()(show.show)
+app.command(context_settings={"help_option_names": ["--help"]})(show.show)
 app.command()(validate.validate)
 
 if __name__ == "__main__":

--- a/nornflow/cli/show.py
+++ b/nornflow/cli/show.py
@@ -27,25 +27,24 @@ from nornflow.masking import mask_structure
 app = typer.Typer()
 
 
-@app.command()
+@app.command(context_settings={"help_option_names": ["--help"]})
 def show(  # noqa: PLR0912
     ctx: typer.Context,
-    catalog: bool = typer.Option(
-        False,
-        "--catalog",
-        "-c",
-        help="Display the task, workflow, and filter catalogs (legacy option)",
-        hidden=True,
-    ),
     catalogs: bool = typer.Option(
-        False, "--catalogs", help="Display all catalogs: tasks, filters, workflows, and blueprints"
+        False,
+        "--catalogs",
+        "-c",
+        help=(
+            "Display all catalogs: tasks, filters, workflows, blueprints, "
+            "j2-filters, and hooks"
+        ),
     ),
     tasks: bool = typer.Option(False, "--tasks", "-t", help="Display the task catalog"),
     filters: bool = typer.Option(False, "--filters", "-f", help="Display the filter catalog"),
     workflows: bool = typer.Option(False, "--workflows", "-w", help="Display the workflow catalog"),
     blueprints: bool = typer.Option(False, "--blueprints", "-b", help="Display the blueprint catalog"),
     j2_filters: bool = typer.Option(False, "--j2-filters", "-j", help="Display the Jinja2 filters catalog"),
-    hooks: bool = typer.Option(False, "--hooks", help="Display the hooks catalog"),
+    hooks: bool = typer.Option(False, "--hooks", "-h", help="Display the hooks catalog"),
     settings: bool = typer.Option(False, "--settings", "-s", help="Display current NornFlow Settings"),
     nornir_configs: bool = typer.Option(
         False, "--nornir-configs", "-n", help="Display current Nornir Configs"
@@ -65,11 +64,9 @@ def show(  # noqa: PLR0912
         print_nox()
         return
 
-    show_all_catalogs = catalog or catalogs
-
     if not any(
         [
-            show_all_catalogs,
+            catalogs,
             tasks,
             filters,
             workflows,
@@ -117,7 +114,7 @@ def show(  # noqa: PLR0912
             show_nornflow_settings(nornflow, redaction_enabled=redaction_enabled)
             show_nornir_configs(nornflow, redaction_enabled=redaction_enabled)
         else:
-            if show_all_catalogs:
+            if catalogs:
                 show_tasks_catalog(nornflow)
                 show_filters_catalog(nornflow)
                 show_workflows_catalog(nornflow)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "nornflow"
-version = "0.9.1"
+version = "1.0.0"
 description = "A workflow orchestration tool for network automation built around Nornir."
 readme = "README.md"
 requires-python = ">=3.10"

--- a/tests/unit/cli/test_show.py
+++ b/tests/unit/cli/test_show.py
@@ -665,13 +665,6 @@ class TestShowCliShortOptions:
     def runner(self) -> CliRunner:
         return CliRunner()
 
-    def test_show_help_lists_catalogs_and_hooks_short_options(self, runner: CliRunner) -> None:
-        """--help documents -c for --catalogs and -h for --hooks."""
-        result = runner.invoke(app, ["show", "--help"])
-        assert result.exit_code == 0
-        assert "--catalogs" in result.output and "-c" in result.output
-        assert "--hooks" in result.output and "-h" in result.output
-
     @patch("nornflow.cli.show.show_hooks_catalog")
     @patch("nornflow.cli.show.NornFlowBuilder")
     def test_show_hooks_short_option(

--- a/tests/unit/cli/test_show.py
+++ b/tests/unit/cli/test_show.py
@@ -4,7 +4,9 @@ from unittest.mock import MagicMock, call, patch
 import pytest
 import typer
 import yaml
+from typer.testing import CliRunner
 
+from nornflow.cli.entrypoint import app
 from nornflow.cli.show import (
     get_catalog_table_headers,
     render_blueprints_catalog_table_data,
@@ -56,7 +58,7 @@ class TestShowCommand:
         mock_ctx = MagicMock()
         mock_ctx.obj = {}
 
-        show(mock_ctx, catalog=False, catalogs=False, tasks=False, filters=False,
+        show(mock_ctx, catalogs=False, tasks=False, filters=False,
              workflows=False, settings=False, nornir_configs=False, all=True, no_redact=False)
 
         mock_show_tasks.assert_called_once_with(mock_nornflow)
@@ -72,11 +74,11 @@ class TestShowCommand:
     @patch("nornflow.cli.show.show_workflows_catalog")
     @patch("nornflow.cli.show.show_nornflow_settings")
     @patch("nornflow.cli.show.show_nornir_configs")
-    def test_show_catalog_flag(
+    def test_show_catalogs_flag(
         self, mock_show_nornir_configs, mock_show_settings, mock_show_workflows,
         mock_show_filters, mock_show_tasks, mock_builder
     ):
-        """Test 'show' with --catalog flag displays only catalog."""
+        """Test 'show' with --catalogs flag displays all catalogs."""
         mock_nornflow = MagicMock()
         mock_builder_instance = MagicMock()
         mock_builder.return_value = mock_builder_instance
@@ -84,7 +86,7 @@ class TestShowCommand:
         mock_ctx = MagicMock()
         mock_ctx.obj = {}
 
-        show(mock_ctx, catalog=True, catalogs=False, tasks=False, filters=False,
+        show(mock_ctx, catalogs=True, tasks=False, filters=False,
              workflows=False, settings=False, nornir_configs=False, all=False)
 
         mock_show_tasks.assert_called_once_with(mock_nornflow)
@@ -113,7 +115,7 @@ class TestShowCommand:
         mock_ctx = MagicMock()
         mock_ctx.obj = {}
 
-        show(mock_ctx, catalog=False, catalogs=False, tasks=False, filters=False,
+        show(mock_ctx, catalogs=False, tasks=False, filters=False,
              workflows=False, settings=True, nornir_configs=False, all=False, no_redact=False)
 
         mock_show_tasks.assert_not_called()
@@ -142,7 +144,7 @@ class TestShowCommand:
         mock_ctx = MagicMock()
         mock_ctx.obj = {}
 
-        show(mock_ctx, catalog=False, catalogs=False, tasks=False, filters=False,
+        show(mock_ctx, catalogs=False, tasks=False, filters=False,
              workflows=False, settings=False, nornir_configs=True, all=False, no_redact=False)
 
         mock_show_tasks.assert_not_called()
@@ -169,7 +171,7 @@ class TestShowCommand:
         mock_ctx = MagicMock()
         mock_ctx.obj = {"settings": "custom_settings.yaml"}
 
-        show(mock_ctx, catalog=False, catalogs=False, tasks=False, filters=False,
+        show(mock_ctx, catalogs=False, tasks=False, filters=False,
              workflows=False, settings=False, nornir_configs=False, all=True)
 
         mock_builder_instance.with_settings_path.assert_called_once_with("custom_settings.yaml")
@@ -186,7 +188,7 @@ class TestShowCommand:
         mock_ctx.obj = {}
     
         with pytest.raises(typer.BadParameter):
-            show(mock_ctx, catalog=False, catalogs=False, tasks=False, filters=False,
+            show(mock_ctx, catalogs=False, tasks=False, filters=False,
                  workflows=False, blueprints=False, j2_filters=False, hooks=False, settings=False, nornir_configs=False, all=False)
 
     @patch("nornflow.cli.show.NornFlowBuilder")
@@ -206,7 +208,7 @@ class TestShowCommand:
         with patch("nornflow.cli.show.typer") as mock_typer:
             mock_typer.Exit = MockExit
             with pytest.raises(MockExit) as exc_info:
-                show(mock_ctx, catalog=False, catalogs=False, tasks=False, filters=False,
+                show(mock_ctx, catalogs=False, tasks=False, filters=False,
                      workflows=False, settings=True, nornir_configs=False, all=False)
 
             assert exc_info.value.code == 2
@@ -228,7 +230,7 @@ class TestShowCommand:
         with patch("nornflow.cli.show.typer") as mock_typer:
             mock_typer.Exit = MockExit
             with pytest.raises(MockExit) as exc_info:
-                show(mock_ctx, catalog=False, catalogs=False, tasks=False, filters=False,
+                show(mock_ctx, catalogs=False, tasks=False, filters=False,
                      workflows=False, settings=True, nornir_configs=False, all=False)
 
             assert exc_info.value.code == 2
@@ -250,7 +252,7 @@ class TestShowCommand:
         with patch("nornflow.cli.show.typer") as mock_typer:
             mock_typer.Exit = MockExit
             with pytest.raises(MockExit) as exc_info:
-                show(mock_ctx, catalog=False, catalogs=False, tasks=False, filters=False,
+                show(mock_ctx, catalogs=False, tasks=False, filters=False,
                      workflows=False, settings=True, nornir_configs=False, all=False)
 
             assert exc_info.value.code == 2
@@ -642,7 +644,6 @@ class TestNoRedact:
 
         show(
             mock_ctx,
-            catalog=False,
             catalogs=False,
             tasks=False,
             filters=False,
@@ -655,3 +656,54 @@ class TestNoRedact:
 
         mock_builder_instance.with_kwargs.assert_called_once_with(no_redact=True)
         mock_show_settings.assert_called_once_with(mock_nornflow, redaction_enabled=False)
+
+
+class TestShowCliShortOptions:
+    """CLI short-option coverage for nornflow show."""
+
+    @pytest.fixture
+    def runner(self) -> CliRunner:
+        return CliRunner()
+
+    def test_show_help_lists_catalogs_and_hooks_short_options(self, runner: CliRunner) -> None:
+        """--help documents -c for --catalogs and -h for --hooks."""
+        result = runner.invoke(app, ["show", "--help"])
+        assert result.exit_code == 0
+        assert "--catalogs" in result.output and "-c" in result.output
+        assert "--hooks" in result.output and "-h" in result.output
+
+    @patch("nornflow.cli.show.show_hooks_catalog")
+    @patch("nornflow.cli.show.NornFlowBuilder")
+    def test_show_hooks_short_option(
+        self, mock_builder: MagicMock, mock_hooks: MagicMock, runner: CliRunner
+    ) -> None:
+        """-h selects the hooks catalog instead of showing command help."""
+        mock_nornflow = MagicMock()
+        mock_nornflow.redaction_enabled = True
+        mock_nornflow.logs_redaction_enabled = True
+        mock_builder_instance = MagicMock()
+        mock_builder.return_value = mock_builder_instance
+        mock_builder_instance.build.return_value = mock_nornflow
+
+        result = runner.invoke(app, ["show", "-h"])
+
+        assert result.exit_code == 0
+        mock_hooks.assert_called_once_with(mock_nornflow)
+
+    @patch("nornflow.cli.show.show_tasks_catalog")
+    @patch("nornflow.cli.show.NornFlowBuilder")
+    def test_show_catalogs_short_option(
+        self, mock_builder: MagicMock, mock_tasks: MagicMock, runner: CliRunner
+    ) -> None:
+        """-c selects --catalogs."""
+        mock_nornflow = MagicMock()
+        mock_nornflow.redaction_enabled = True
+        mock_nornflow.logs_redaction_enabled = True
+        mock_builder_instance = MagicMock()
+        mock_builder.return_value = mock_builder_instance
+        mock_builder_instance.build.return_value = mock_nornflow
+
+        result = runner.invoke(app, ["show", "-c"])
+
+        assert result.exit_code == 0
+        mock_tasks.assert_called_once_with(mock_nornflow)


### PR DESCRIPTION
Promote `develop` to `main` for the NornFlow **1.0.0** stable release.